### PR TITLE
Add yubikey-totp desktop application

### DIFF
--- a/nixosModules/mako/config
+++ b/nixosModules/mako/config
@@ -19,6 +19,10 @@ on-notify=none
 [app-name=dnd]
 invisible=0
 
+# Notifications that should not play sound (user-initiated actions)
+[category=no-sound]
+on-notify=none
+
 [app-name=speaker-status]
 on-notify=none
 border-size=0

--- a/nixosModules/yubikey.nix
+++ b/nixosModules/yubikey.nix
@@ -2,15 +2,22 @@
   config,
   lib,
   pkgs,
+  thoughtfull,
   ...
 }:
 let
   inherit (lib) mkDefault mkEnableOption mkIf;
+  inherit (pkgs)
+    age-plugin-yubikey
+    yubioath-flutter
+    ;
+  inherit (thoughtfull.pkgs) yubikey-totp;
 in
 {
   config = mkIf config.thoughtfull.yubikey.enable {
-    environment.systemPackages = with pkgs; [
+    environment.systemPackages = [
       age-plugin-yubikey
+      yubikey-totp
       yubioath-flutter
     ];
     hardware.gpgSmartcards.enable = mkDefault true;

--- a/packages.nix
+++ b/packages.nix
@@ -22,6 +22,7 @@ let
     writeFileScriptBin
     ;
 in
+# Keep these alphabetized
 {
   attach-yubikey = writeArgcScript "attach-yubikey" ./packages/attach-yubikey.bash {
     bash = "${bash}/bin/bash";
@@ -43,6 +44,7 @@ in
     ssh-add = "${openssh}/bin/ssh-add";
     ssh-agent = "${openssh}/bin/ssh-agent";
   };
+  options-doc = import ./packages/options-doc self;
   pins = import ./packages/pins.nix self;
   power-menu = import ./packages/power-menu.nix self;
   run-vm = writeArgcScript "run-vm" ./packages/run-vm.bash {
@@ -64,5 +66,5 @@ in
     };
     src = ./packages/waybar-yubikey.bash;
   };
-  options-doc = import ./packages/options-doc self;
+  yubikey-totp = import ./packages/yubikey-totp.nix self;
 }

--- a/packages/yubikey-totp.nix
+++ b/packages/yubikey-totp.nix
@@ -1,0 +1,57 @@
+{ lib, pkgs, ... }:
+let
+  inherit (pkgs)
+    makeDesktopItem
+    symlinkJoin
+    ;
+  inherit (pkgs.lib) makeOverridable;
+  inherit (lib) writeFileScriptBin;
+in
+makeOverridable
+  (
+    {
+      bash,
+      fuzzel,
+      libnotify,
+      wl-clipboard,
+      yubikey-manager,
+    }:
+    let
+      yubikey-totp-script = writeFileScriptBin {
+        name = "yubikey-totp";
+        replacements = {
+          bash = "${bash}/bin/bash";
+          fuzzel = "${fuzzel}/bin/fuzzel";
+          notify_send = "${libnotify}/bin/notify-send";
+          wl_copy = "${wl-clipboard}/bin/wl-copy";
+          ykman = "${yubikey-manager}/bin/ykman";
+        };
+        src = ./yubikey-totp/yubikey-totp.bash;
+      };
+      yubikey-totp-desktop = makeDesktopItem {
+        name = "yubikey-totp";
+        desktopName = "Grab TOTP from Yubikey";
+        exec = "${yubikey-totp-script}/bin/yubikey-totp";
+        icon = "security-high";
+        terminal = false;
+        type = "Application";
+        categories = [ "Utility" ];
+      };
+    in
+    symlinkJoin {
+      name = "yubikey-totp";
+      paths = [
+        yubikey-totp-script
+        yubikey-totp-desktop
+      ];
+    }
+  )
+  {
+    inherit (pkgs)
+      bash
+      fuzzel
+      libnotify
+      wl-clipboard
+      yubikey-manager
+      ;
+  }

--- a/packages/yubikey-totp/yubikey-totp.bash
+++ b/packages/yubikey-totp/yubikey-totp.bash
@@ -1,0 +1,62 @@
+#!@bash@
+set -euo pipefail
+
+# Get list of yubikey serial numbers
+serials=$(@ykman@ list --serials)
+
+if [[ -z $serials ]]; then
+  @notify_send@ -u critical "No YubiKey detected"
+  exit 1
+fi
+
+# Count number of yubikeys
+serial_count=$(echo "$serials" | wc -l)
+
+if [[ $serial_count -eq 1 ]]; then
+  serial="$serials"
+else
+  # Multiple yubikeys, use fuzzel to select
+  serial=$(echo "$serials" | @fuzzel@ --dmenu --width=40 --prompt "Select YubiKey: ")
+  if [[ -z $serial ]]; then
+    exit 0
+  fi
+fi
+
+# Get list of TOTP accounts from the selected yubikey
+accounts=$(@ykman@ --device "$serial" oath accounts list 2>/dev/null)
+
+if [[ -z $accounts ]]; then
+  @notify_send@ -u critical "No OATH accounts on YubiKey $serial"
+  exit 1
+fi
+
+# Create arrays for display and original account names
+declare -a display_accounts
+declare -a original_accounts
+
+while IFS= read -r account; do
+  original_accounts+=("$account")
+  # Replace first : with → for nicer display
+  display_accounts+=("${account/:/ → }")
+done <<<"$accounts"
+
+# Use fuzzel to select an account
+selected_display=$(printf '%s\n' "${display_accounts[@]}" | @fuzzel@ --dmenu --width=60 --prompt "Select account: ")
+
+if [[ -z $selected_display ]]; then
+  exit 0
+fi
+
+# Map the display selection back to the original account name
+for i in "${!display_accounts[@]}"; do
+  if [[ ${display_accounts[$i]} == "$selected_display" ]]; then
+    account="${original_accounts[$i]}"
+    break
+  fi
+done
+
+# Get the TOTP code and copy to clipboard
+code=$(@ykman@ --device "$serial" oath accounts code -s "$account")
+echo -n "$code" | @wl_copy@
+
+@notify_send@ -c no-sound "TOTP code copied" "$selected_display"


### PR DESCRIPTION
## Summary
- Adds a new desktop application for grabbing TOTP codes from YubiKeys
- Script handles multiple YubiKeys with selection prompt
- Displays OATH accounts in a readable format (Issuer → Account)
- Copies selected TOTP code to clipboard and shows notification
- Accessible via fuzzel launcher as "Grab TOTP from Yubikey"

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)