### PR TITLE
Disable zsh command hashing (fixes #32)

### DIFF
--- a/nixosModules/zsh.nix
+++ b/nixosModules/zsh.nix
@@ -39,6 +39,8 @@ in
       "HIST_FIND_NO_DUPS"
       # do not store duplicate of previous command
       "HIST_IGNORE_DUPS"
+      # disable command hashing to immediately see new scripts after nixos-rebuild
+      "NO_HASH_CMDS"
       # make history available immediately across shell instances
       "SHARE_HISTORY"
     ];


### PR DESCRIPTION
## Summary
- Added `NO_HASH_CMDS` option to zsh configuration to disable command hashing
- New scripts and commands are now immediately available after `nixos-rebuild switch` without requiring manual `rehash`

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)