### PR TITLE
Add monitoring module for systemd failures via ntfy

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -86,11 +86,11 @@
     },
     "kryptonix": {
       "locked": {
-        "lastModified": 1773271210,
-        "narHash": "sha256-ur3F9DWbUIwGiW2xAB+jvAHFoSZN15OEPn6VAcQ3LuA=",
+        "lastModified": 1773447636,
+        "narHash": "sha256-sGTuLpkbt5DYGq0fQI3cjI6PlW5TvdGZHLof36NC5dU=",
         "ref": "sedna",
-        "rev": "be25bff0177f391c0a6567f1336d0affc9fef008",
-        "revCount": 6,
+        "rev": "5484fba185c28740b4841615c1f0c2ef71f8cbf1",
+        "revCount": 7,
         "type": "git",
         "url": "ssh://git@github.com/technosophist/kryptonix"
       },

--- a/nixosConfigurations/sedna.nix
+++ b/nixosConfigurations/sedna.nix
@@ -86,6 +86,16 @@
             enable = true;
             user.directories = [ "src" ];
           };
+          monitoring = {
+            enable = true;
+            services = [
+              "sshd"
+              "syncthing"
+              "restic-backups-default"
+              "mako"
+              "test-failure"
+            ];
+          };
           programs.obsidian.enable = true;
           rust.enable = true;
           user = {

--- a/nixosModules.nix
+++ b/nixosModules.nix
@@ -37,6 +37,7 @@ self: {
         ./nixosModules/javascript.nix
         ./nixosModules/less.nix
         ./nixosModules/mako.nix
+        ./nixosModules/monitoring.nix
         ./nixosModules/obsidian.nix
         ./nixosModules/openssh.nix
         ./nixosModules/pipewire.nix

--- a/nixosModules/monitoring.nix
+++ b/nixosModules/monitoring.nix
@@ -1,0 +1,71 @@
+{
+  config,
+  lib,
+  pkgs,
+  thoughtfull,
+  ...
+}:
+let
+  inherit (lib)
+    mkDefault
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    ;
+  inherit (pkgs) curl;
+  inherit (thoughtfull.lib) writeFileScriptBin;
+  cfg = config.thoughtfull.monitoring;
+
+  alert-script = writeFileScriptBin {
+    name = "ntfy";
+    replacements = {
+      curl = "${curl}/bin/curl";
+      systemctl = "${pkgs.systemd}/bin/systemctl";
+      ntfyServer = cfg.ntfyServer;
+      ntfyTopic = cfg.ntfyTopic;
+    };
+    src = ./monitoring/ntfy.bash;
+  };
+in
+{
+  config = mkIf cfg.enable {
+    systemd.services = {
+      "alert-on-failure@" = {
+        description = "Send alert for failed unit %i";
+        environment = {
+          UNIT = "%i";
+          HOST = "%H";
+        };
+        path = [ pkgs.bash ];
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = "${alert-script}/bin/ntfy";
+        };
+      };
+    } // (lib.attrsets.genAttrs cfg.services (name: {
+      onFailure = [ "alert-on-failure@%n.service" ];
+    }));
+  };
+
+  options.thoughtfull.monitoring = {
+    enable = mkEnableOption "systemd failure monitoring via ntfy";
+
+    ntfyServer = mkOption {
+      type = types.str;
+      default = "https://ntfy.sh";
+      description = "URL of the ntfy server";
+    };
+
+    ntfyTopic = mkOption {
+      type = types.str;
+      description = "Topic to publish alerts to";
+    };
+
+    services = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "List of systemd services to monitor for failures";
+    };
+  };
+}

--- a/nixosModules/monitoring/ntfy.bash
+++ b/nixosModules/monitoring/ntfy.bash
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get human-readable description from systemd
+DESCRIPTION=$(@systemctl@ show -p Description "${UNIT}" | cut -d= -f2-)
+
+MESSAGE="${DESCRIPTION} failed on ${HOST}
+
+\`\`\`
+$(SYSTEMD_COLORS=0 @systemctl@ --no-pager status "${UNIT}" 2>&1 || true)
+\`\`\`"
+
+@curl@ \
+  -H "Title: ${DESCRIPTION} failed" \
+  -H "Priority: high" \
+  -H "Tags: x" \
+  -H "Markdown: yes" \
+  -d "${MESSAGE}" \
+  @ntfyServer@/@ntfyTopic@


### PR DESCRIPTION
## Summary

Implements issue #97 - adds a new NixOS module that sends ntfy notifications when systemd services fail.

- Monitors specified systemd services for failures
- Sends alerts via ntfy with service description and status output
- Uses systemd's Description field for human-readable service names
- Formats status output as markdown code blocks
- Configurable ntfy server and topic

🤖 Generated with [Claude Code](https://claude.com/claude-code)