### PR TITLE
Add test infrastructure and avahi module tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,55 @@ Custom packages in `packages/` use template substitution via `replaceVars` to in
 - `nixosConfigurations/bootstrap.nix`: Template for provisioning new systems with `BOOTSTRAP` replaced with the name of the provisioned system.
 - `nixosConfigurations/nixos.nix`: Minimal ISO environment for initial provisioning
 
+## Testing
+
+Tests are located in the `tests/` directory. Each module should have a corresponding test file (e.g., `tests/avahi.nix` for `nixosModules/avahi.nix`).
+
+### Running Tests
+
+```bash
+# Run all tests
+nix flake check
+
+# Run a specific test (e.g., avahi)
+nix build .#checks.x86_64-linux.avahi
+
+# Run test in interactive mode for debugging
+nix build .#checks.x86_64-linux.avahi.driverInteractive
+./result/bin/nixos-test-driver
+```
+
+### Test-Driven Development Workflow
+
+When modifying a module, follow this workflow:
+
+1. **Update test expectations first** - Modify the test in `tests/` to reflect the desired behavior
+2. **Wait for user review** - Present the test changes to the user and wait for approval before proceeding
+3. **Verify the test fails** - After approval, run the specific test to confirm it fails as expected
+4. **Update the module** - Make changes to the module in `nixosModules/`
+5. **Verify the test passes** - Run the test again to confirm it now passes
+
+**IMPORTANT: Always wait for user review and approval of test changes before running tests or modifying modules.** This ensures the user understands what behavior is being tested and agrees with the approach before implementation begins.
+
+### Test Structure
+
+Tests use NixOS VM testing framework (`nixpkgs.testers.nixosTest`). A typical test:
+- Imports the module being tested
+- Sets up one or more test VMs
+- Runs commands to verify expected behavior
+- Tests default values (use module's `mkDefault` settings without overriding)
+
+## Git and Version Control
+
+**IMPORTANT: Never commit or push changes automatically. Always present changes for user review and approval before committing.**
+
+When the user requests commits:
+- Present a summary of changes
+- Wait for explicit user approval
+- Only create commits after approval is given
+
+**Never push commits to remote repositories unless explicitly instructed by the user.** After creating commits, inform the user that changes are ready to push but wait for their explicit instruction to do so.
+
 ## Conventions
 
 - Use `mkDefault` for all option values to allow overrides in host configurations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ This is a NixOS flake-based system configuration framework using nixpkgs 25.11 w
 
 ### Module System
 
-All modules in `nixosModules/` are auto-imported via `lib.dirPaths`. Modules use NixOS options to conditionally enable features rather than conditional imports.
+All modules in `nixosModules/` are imported unconditionally. Modules use NixOS options to conditionally enable features rather than conditional imports.  New modules are manually added to `nixosModules.nix` (using `lib.dirPaths` prevented the options documentation from linking to the correct file).
 
 **Module patterns:**
 - Simple module: Single `.nix` file (for example, `git.nix`)
@@ -50,22 +50,27 @@ in
 }
 ```
 
-**Custom namespace:** All custom options live under `config.thoughtfull.*`:
+**Custom namespace:** Modules for new programs and services or global options or "category" modules that configure across multiple programs/services (for example, `rust.nix` installs system packages, emacs packages, configures environment variables, etc.) live under `config.thoughtfull.*`:
 - `thoughtfull.user` - User account configuration
 - `thoughtfull.impermanence` - Stateless root configuration
 - `thoughtfull.graphical` - Graphical environment toggle
 - `thoughtfull.programs.*` - Program-specific options
+- `thoughtfull.rust` - Category module
+
+**Extending upstream modules:** Usually upstream modules are configured with reasonable defaults and only enabled if they're a dependency of a category module or some other module, or if the user enables it in a nixosConfiguration.  Sometimes extensions to upstream NixOS modules add a `thoughtfull` option to the upstream options.  For example for `services.syncthing` there's `services.syncthing.thoughtfull.keyFile` etc.
+
+**Scripts:** Scripts in modules should assume the programs they need exist on the path.  They should avoid binding directly to specific binaries in the nix store.  This allows for a rebuild switch without breaking things or having to restart a bunch of things so they see new versions of executables.  In particular, scripts using, say, bash should use `#!/usr/bin/env bash` and ensure that `programs.bash.enable` is true, and similarly for other programs.
 
 ### Key Library Functions (lib.nix)
 
-- `dirPaths`: Import all .nix files in a directory as modules
 - `dirFiles`: List .nix files in a directory
 - `nixosConfiguration`: Helper wrapping `nixpkgs.lib.nixosSystem` with dependency injection
 - `githubKeys`: Fetch SSH public keys from GitHub by username
+- `writeArgcScript`: Write bash script using Argc framework
 
 ### Package System
 
-Custom packages in `packages/` use template substitution via `replaceVars` to inject tool paths at build time. Scripts use `@meta` argc annotations for CLI argument parsing (see `packages/nixfiles.bash`).
+Custom packages in `packages/` use template substitution via `replaceVars` to inject tool paths at build time. Packages should be overridable so the NixOS modules can pass in customized versions of dependent packages.  Simple scripts can be written simply.  Scripts meant for user interaction or needing to take arguments, should use `lib.writeArgcScript` and use the Argc Bash framework.
 
 ### Host Configurations
 

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
       inherit (self.lib) forEachSystem;
     in
     {
+      checks = import ./tests.nix self;
       emacsPackages = import ./emacsPackages.nix self;
       lib = import ./lib.nix self;
       nixosConfigurations = import ./nixosConfigurations.nix self;

--- a/tests.nix
+++ b/tests.nix
@@ -1,0 +1,18 @@
+self@{
+  inputs,
+  lib,
+  ...
+}:
+let
+  inherit (lib) forEachSystem;
+in
+forEachSystem (
+  system:
+  let
+    nixpkgs = inputs.nixpkgs.legacyPackages.${system};
+    callTest = path: import path { inherit self nixpkgs; };
+  in
+  {
+    avahi = callTest ./tests/avahi.nix;
+  }
+)

--- a/tests/avahi.nix
+++ b/tests/avahi.nix
@@ -1,0 +1,103 @@
+{ self, nixpkgs, ... }:
+nixpkgs.testers.nixosTest {
+  name = "avahi";
+
+  skipTypeCheck = true;
+  skipLint = true;
+
+  nodes = {
+    server = {
+      imports = [ ../nixosModules/avahi.nix ];
+
+      # The module should enable avahi by default, so we don't set it explicitly
+      # This tests that the module's mkDefault true works correctly
+
+      # Add a test service to publish
+      services.avahi.publish = {
+        userServices = true;
+      };
+
+      # Configure hostname for testing
+      networking.hostName = "testserver";
+      # Firewall should be opened by the module
+    };
+
+    client = {
+      imports = [ ../nixosModules/avahi.nix ];
+
+      # The module should enable avahi by default, so we don't set it explicitly
+      # This tests that the module's mkDefault true works correctly
+      networking.hostName = "testclient";
+      # Firewall should be opened by the module
+    };
+  };
+
+  testScript = ''
+    server = globals()["testserver"]
+    client = globals()["testclient"]
+
+    start_all()
+
+    # Wait for avahi-daemon to be running on both nodes
+    server.wait_for_unit("avahi-daemon.service")
+    client.wait_for_unit("avahi-daemon.service")
+
+    # Verify avahi-daemon is running
+    server.succeed("systemctl is-active avahi-daemon.service")
+    client.succeed("systemctl is-active avahi-daemon.service")
+
+    # Check that avahi binaries are available
+    server.succeed("which avahi-browse")
+    client.succeed("which avahi-browse")
+
+    # Verify NSS mDNS integration is enabled
+    server.succeed("grep -q mdns4_minimal /etc/nsswitch.conf")
+    client.succeed("grep -q mdns4_minimal /etc/nsswitch.conf")
+
+    # Wait for network to settle and allow mDNS to propagate
+    server.sleep(5)
+    client.sleep(5)
+
+    # Test mDNS hostname resolution from client to server
+    # The server should be resolvable as testserver.local
+    with subtest("mDNS hostname resolution"):
+        client.succeed("getent hosts testserver.local", timeout=30)
+
+    # Test that avahi can browse services
+    with subtest("service browsing"):
+        server.succeed("avahi-browse -a -t", timeout=10)
+        client.succeed("avahi-browse -a -t", timeout=10)
+
+    # Test that avahi-resolve works
+    with subtest("avahi-resolve"):
+        server.succeed("avahi-resolve --name testserver.local", timeout=10)
+
+    # Test that address records are being published
+    with subtest("address publishing"):
+        # Resolve the hostname and capture the IP address
+        server_ip = client.succeed("avahi-resolve --name testserver.local | awk '{print $2}'").strip()
+        print(f"Server IP from mDNS: {server_ip}")
+
+        # Verify reverse address lookup works (tests that addresses are published)
+        reverse_result = client.succeed(f"avahi-resolve-address {server_ip}", timeout=10)
+        assert "testserver.local" in reverse_result, "Reverse address lookup should return hostname"
+
+        # Verify the client can also resolve its own address
+        client_ip = client.succeed("avahi-resolve --name testclient.local | awk '{print $2}'").strip()
+        print(f"Client IP from mDNS: {client_ip}")
+
+    # Test domain publishing by checking browse output
+    with subtest("domain publishing"):
+        # Browse all services with full details to see what's published
+        browse_output = client.succeed("avahi-browse -a -t -r -p", timeout=15)
+        # With domain publishing enabled, we should see .local domain announcements
+        # The -p flag gives parseable output
+        assert ".local" in browse_output, "Domain publishing should announce .local domain"
+
+    # Test that we can discover the server from the client
+    with subtest("cross-node discovery"):
+        # Verify cross-node name resolution works via mDNS
+        # This is the key integration test for avahi functionality
+        client.wait_until_succeeds("ping -c 1 testserver.local", timeout=30)
+  '';
+}


### PR DESCRIPTION
## Summary

This PR adds a comprehensive testing framework and tests for NixOS modules, starting with the avahi module.

### Changes

- **Test Infrastructure**
  - Add `tests.nix` to manage test suite
  - Add `checks` output to `flake.nix` for running tests via `nix flake check`
  - Tests can be run individually with `nix build .#checks.x86_64-linux.<test-name>`

- **Avahi Module Tests** (`tests/avahi.nix`)
  - Validates module enables avahi by default (tests `mkDefault` behavior)
  - Tests service activation and daemon health
  - Verifies NSS mDNS integration
  - Tests forward and reverse address resolution
  - Validates domain publishing (.local domain)
  - Tests cross-node mDNS discovery
  - Verifies avahi-browse and avahi-resolve functionality

- **Documentation** (`CLAUDE.md`)
  - Document testing practices and TDD workflow
  - Add git workflow requirements (no auto-commits/pushes)
  - Document test structure and running tests

### Running Tests

```bash
# Run all tests
nix flake check

# Run avahi test specifically
nix build .#checks.x86_64-linux.avahi

# Interactive debugging
nix build .#checks.x86_64-linux.avahi.driverInteractive
./result/bin/nixos-test-driver
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)