### PR TITLE
Fix options-doc reference to renamed installer configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,8 @@ Custom packages in `packages/` use template substitution via `replaceVars` to in
 ### Host Configurations
 
 - `nixosConfigurations/bootstrap.nix`: Template for provisioning new systems with `BOOTSTRAP` replaced with the name of the provisioned system.
-- `nixosConfigurations/nixos.nix`: Minimal ISO environment for initial provisioning
+- `nixosConfigurations/installer.nix`: Minimal ISO environment for initial provisioning
+- `nixosConfigurations/installer-rpi4.nix`: SD card image for Raspberry Pi 4 provisioning
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,11 @@ direnv allow
 # Check flake validity
 nix flake check
 
-# Build ISO image for nixos
-nix build .#nixosConfigurations.nixos.config.system.build.isoImage
+# Build ISO image for installer
+nix build .#nixosConfigurations.installer.config.system.build.isoImage
+
+# Build SD card image for Raspberry Pi 4
+nix build .#nixosConfigurations.installer-rpi4.config.system.build.sdImage
 
 # Verify changes by running pre-commit hooks
 devenv tasks run devenv:git-hooks:run

--- a/packages/options-doc/default.nix
+++ b/packages/options-doc/default.nix
@@ -12,7 +12,7 @@ let
   };
 
   # Use the ISO config (has all modules, no secrets)
-  nixosSystem = self.nixosConfigurations.nixos;
+  nixosSystem = self.nixosConfigurations.installer;
 
   # Transform declarations to GitHub URLs
   # Match by path patterns since store paths differ between evaluation contexts


### PR DESCRIPTION
## Summary
- Update `packages/options-doc/default.nix` to reference `nixosConfigurations.installer` instead of the removed `nixosConfigurations.nixos`
- Update CLAUDE.md build commands to match the renamed configuration
- Add SD card image build command for `installer-rpi4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)