### PR TITLE
Add NTP module

### DIFF
--- a/nixosModules/default.nix
+++ b/nixosModules/default.nix
@@ -62,6 +62,7 @@ in
     ./less.nix
     ./mako.nix
     ./monitoring.nix
+    ./ntp.nix
     ./obsidian.nix
     ./openssh.nix
     ./pipewire.nix

--- a/nixosModules/ntp.nix
+++ b/nixosModules/ntp.nix
@@ -1,0 +1,7 @@
+{ lib, ... }:
+let
+  inherit (lib) mkDefault;
+in
+{
+  services.ntp.enable = mkDefault true;
+}


### PR DESCRIPTION
## Summary
- Add new `ntp.nix` module that enables NTP time synchronization by default
- Register the module in `nixosModules/default.nix`