### PR TITLE
Add boot module to centralize boot configuration

### DIFF
--- a/nixosConfigurations/bootstrap.nix
+++ b/nixosConfigurations/bootstrap.nix
@@ -4,20 +4,6 @@
     (
       { pkgs, ... }:
       {
-        boot = {
-          initrd = {
-            luks.devices.encrypted.crypttabExtraOpts = [
-              "fido2-device=auto"
-              "token-timeout=5s"
-            ];
-            systemd.enable = true;
-          };
-          loader = {
-            efi.canTouchEfiVariables = true;
-            grub.enable = false;
-            systemd-boot.enable = true;
-          };
-        };
         environment.systemPackages = [ pkgs.devenv ];
         imports = [
           ./BOOTSTRAP/hardware-configuration.nix

--- a/nixosConfigurations/sedna.nix
+++ b/nixosConfigurations/sedna.nix
@@ -4,21 +4,7 @@
     (
       { pkgs, ... }:
       {
-        boot = {
-          binfmt.emulatedSystems = [ "aarch64-linux" ];
-          initrd = {
-            luks.devices.encrypted.crypttabExtraOpts = [
-              "fido2-device=auto"
-              "token-timeout=5s"
-            ];
-            systemd.enable = true;
-          };
-          loader = {
-            efi.canTouchEfiVariables = true;
-            grub.enable = false;
-            systemd-boot.enable = true;
-          };
-        };
+        boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
         environment.systemPackages = [
           pkgs.devenv
         ]

--- a/nixosModules/boot.nix
+++ b/nixosModules/boot.nix
@@ -1,0 +1,50 @@
+{
+  config,
+  lib,
+  ...
+}:
+let
+  inherit (lib)
+    mkDefault
+    mkIf
+    mkMerge
+    ;
+  rpi4 = config.thoughtfull.rpi4.enable;
+in
+{
+  config = mkMerge [
+    { boot.initrd.systemd.enable = mkDefault true; }
+    (mkIf (!rpi4) {
+      boot = {
+        initrd.luks.devices.encrypted.crypttabExtraOpts = [
+          "fido2-device=auto"
+          "token-timeout=5s"
+        ];
+        loader = {
+          efi.canTouchEfiVariables = mkDefault true;
+          grub.enable = mkDefault false;
+          systemd-boot.enable = mkDefault true;
+        };
+      };
+    })
+    (mkIf rpi4 {
+      boot.initrd = {
+        network.ssh = {
+          enable = mkDefault true;
+          authorizedKeys = config.users.users.root.openssh.authorizedKeys.keys;
+          port = mkDefault 222;
+        };
+        systemd = {
+          network = {
+            enable = mkDefault true;
+            networks."10-end0" = {
+              matchConfig.Name = mkDefault "end0";
+              networkConfig.DHCP = mkDefault "yes";
+            };
+          };
+          users.root.shell = mkDefault "/bin/systemd-tty-ask-password-agent";
+        };
+      };
+    })
+  ];
+}

--- a/nixosModules/default.nix
+++ b/nixosModules/default.nix
@@ -40,6 +40,7 @@ in
     ./avahi.nix
     ./backlight.nix
     ./bluetooth.nix
+    ./boot.nix
     ./claude.nix
     ./clojure.nix
     ./dictation.nix


### PR DESCRIPTION
## Summary
- Extract common boot settings (LUKS/FIDO2, systemd-boot, EFI) into a new `nixosModules/boot.nix` module
- Add rpi4-specific initrd networking and SSH support to the boot module
- Remove duplicated boot config from bootstrap and sedna host configurations