### PR TITLE
Add assertion requiring root SSH key for rpi4 module

### DIFF
--- a/nixosModules/rpi4.nix
+++ b/nixosModules/rpi4.nix
@@ -9,6 +9,12 @@ let
 in
 {
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.users.users.root.openssh.authorizedKeys.keys != [ ];
+        message = "thoughtfull.rpi4.enable requires at least one root SSH authorized key for initrd remote unlock";
+      }
+    ];
     hardware.enableRedistributableFirmware = mkDefault true;
   };
   options.thoughtfull.rpi4.enable = mkEnableOption "Raspberry Pi 4 configuration";


### PR DESCRIPTION
## Summary
- Adds an assertion to the rpi4 module that requires at least one root SSH authorized key when the module is enabled
- Ensures initrd remote unlock is always possible on Raspberry Pi 4 systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)