### PR TITLE
Remove ntp module

### DIFF
--- a/nixosModules/default.nix
+++ b/nixosModules/default.nix
@@ -63,7 +63,6 @@ in
     ./less.nix
     ./mako.nix
     ./monitoring.nix
-    ./ntp.nix
     ./obsidian.nix
     ./openssh.nix
     ./pipewire.nix

--- a/nixosModules/ntp.nix
+++ b/nixosModules/ntp.nix
@@ -1,7 +1,0 @@
-{ lib, ... }:
-let
-  inherit (lib) mkDefault;
-in
-{
-  services.ntp.enable = mkDefault true;
-}


### PR DESCRIPTION
## Summary
- Remove the `ntp.nix` module which only set `services.ntp.enable = mkDefault true`
- NixOS already provides time synchronization via systemd-timesyncd by default, making this module unnecessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)