### PR TITLE
Fix RPi4 networking by ensuring systemd-networkd over NetworkManager

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -801,11 +801,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1776734388,
-        "narHash": "sha256-vl3dkhlE5gzsItuHoEMVe+DlonsK+0836LIRDnm6MXQ=",
+        "lastModified": 1777428379,
+        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac",
+        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
         "type": "github"
       },
       "original": {

--- a/nixosConfigurations/installer-rpi4.nix
+++ b/nixosConfigurations/installer-rpi4.nix
@@ -6,6 +6,10 @@
     (
       { ... }:
       {
+        boot.initrd = {
+          allowMissingModules = true;
+          network.ssh.enable = false;
+        };
         hardware.raspberry-pi."4".poe-hat.enable = true;
         thoughtfull = {
           installer.enable = true;

--- a/nixosModules/boot.nix
+++ b/nixosModules/boot.nix
@@ -8,6 +8,7 @@ let
     mkDefault
     mkIf
     mkMerge
+    mkOverride
     ;
   rpi4 = config.thoughtfull.rpi4.enable;
 in
@@ -36,13 +37,13 @@ in
         };
         systemd = {
           network = {
-            enable = mkDefault true;
+            enable = mkOverride 900 true;
             networks."10-end0" = {
               matchConfig.Name = mkDefault "end0";
               networkConfig.DHCP = mkDefault "yes";
             };
           };
-          users.root.shell = mkDefault "/bin/systemd-tty-ask-password-agent";
+          users.root.shell = mkOverride 900 "/bin/systemd-tty-ask-password-agent";
         };
       };
     })

--- a/nixosModules/rpi4.nix
+++ b/nixosModules/rpi4.nix
@@ -25,7 +25,7 @@ in
     hardware.enableRedistributableFirmware = mkDefault true;
     networking = {
       networkmanager.enable = mkOverride 900 false;
-      useNetworkd = mkDefault true;
+      useNetworkd = mkOverride 900 true;
     };
   };
   options.thoughtfull.rpi4.enable = mkEnableOption "Raspberry Pi 4 configuration";

--- a/nixosModules/rpi4.nix
+++ b/nixosModules/rpi4.nix
@@ -16,6 +16,10 @@ in
       }
     ];
     hardware.enableRedistributableFirmware = mkDefault true;
+    networking = {
+      networkmanager.enable = mkDefault false;
+      useNetworkd = mkDefault true;
+    };
   };
   options.thoughtfull.rpi4.enable = mkEnableOption "Raspberry Pi 4 configuration";
 }

--- a/nixosModules/rpi4.nix
+++ b/nixosModules/rpi4.nix
@@ -4,20 +4,27 @@
   ...
 }:
 let
-  inherit (lib) mkDefault mkEnableOption mkIf;
+  inherit (lib)
+    mkDefault
+    mkEnableOption
+    mkIf
+    mkOverride
+    ;
   cfg = config.thoughtfull.rpi4;
 in
 {
   config = mkIf cfg.enable {
     assertions = [
       {
-        assertion = config.users.users.root.openssh.authorizedKeys.keys != [ ];
+        assertion =
+          !config.boot.initrd.network.ssh.enable
+          || config.users.users.root.openssh.authorizedKeys.keys != [ ];
         message = "thoughtfull.rpi4.enable requires at least one root SSH authorized key for initrd remote unlock";
       }
     ];
     hardware.enableRedistributableFirmware = mkDefault true;
     networking = {
-      networkmanager.enable = mkDefault false;
+      networkmanager.enable = mkOverride 900 false;
       useNetworkd = mkDefault true;
     };
   };


### PR DESCRIPTION
## Summary

- Explicitly disable NetworkManager and enable systemd-networkd in the RPi4 module to prevent conflicts
- Use `mkOverride 900` instead of `mkDefault` in boot module for networkd and root shell settings so they take priority over other defaults
- Add `boot.initrd.allowMissingModules` and disable initrd SSH for the RPi4 installer
- Update nixpkgs flake input

🤖 Generated with [Claude Code](https://claude.com/claude-code)