### PR TITLE
Remove per-host restic passphrase from provision

### DIFF
--- a/packages/nixfiles.bash
+++ b/packages/nixfiles.bash
@@ -38,7 +38,7 @@ git_user_email="technosophist@thoughtfull.systems"
 ## clone a nixfiles repository, and a GPG key to commit to and push the repository.  The Yubikey is
 ## also setup to unlock the LUKS partition with FIDO2.
 ##
-## A LUKS recovery code and Restic recovery code are generated, encrypted, and committed to the
+## A LUKS recovery code is generated, encrypted, and committed to the
 ## repository along with a bootstrapped NixOS configuration and generated
 ## hardware-configuration.nix.
 ##
@@ -155,7 +155,6 @@ provision() {
   fi
   # == Ensure passphrases
   ensure-passphrase "LUKS recovery passphrase"
-  ensure-passphrase "Restic recovery passphrase"
   if [[ ! -r "${secrets_path}/hashed-user-passphrase.age" ]]; then
     log "Hashing user passphrase"
     user_passphrase=$(phraze)


### PR DESCRIPTION
## Summary
- Remove `ensure-passphrase "Restic recovery passphrase"` from the provision command since restic now uses shared secrets via `nixosConfigurations/shared/secrets`
- Update the provision command's documentation to no longer mention restic recovery codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)