### PR TITLE
Fix ssh to another host sometimes logging into localhost

### DIFF
--- a/nixosModules/openssh.nix
+++ b/nixosModules/openssh.nix
@@ -17,6 +17,12 @@ in
     extraConfig = ''
       VerifyHostKeyDNS yes
       VisualHostKey yes
+      # Workaround: Firewalla returns :: (IPv6 unspecified) AAAA records for
+      # .lan hosts even with IPv6 disabled, causing SSH to fall back to
+      # localhost when the target refuses the connection. Remove this if
+      # Firewalla fixes their DNS behavior.
+      Match host *.lan
+        AddressFamily inet
     '';
     knownHostsFiles = [
       ./openssh/known_hosts_github


### PR DESCRIPTION
Firewalla returns :: AAAA records for .lan hosts even when IPv6 is disabled.  This seems like a conscious choice for some reason.  Whatever the reason, it causes SSH (and other programs) to fallback to localhost if it cannot connect to the remote host.

This fixes the issue with SSH.  I think it is still a problem, like, in Firefox, but I'm not sure what to do about that for now.