### PR TITLE
Add unstable nixpkgs overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,7 +69,9 @@
           "crate2nix"
         ],
         "git-hooks": "git-hooks",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1767714506,
@@ -99,7 +101,9 @@
           "crate2nix_stable"
         ],
         "git-hooks": "git-hooks_2",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1767714506,
@@ -156,7 +160,9 @@
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "nix-test-runner": "nix-test-runner",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
@@ -753,54 +759,6 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765186076,
-        "narHash": "sha256-hM20uyap1a0M9d344I692r+ik4gTMyj60cQWO+hAYP8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "addf7cf5f383a3101ecfba091b98d0a1263dc9b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1765186076,
-        "narHash": "sha256-hM20uyap1a0M9d344I692r+ik4gTMyj60cQWO+hAYP8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "addf7cf5f383a3101ecfba091b98d0a1263dc9b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1769433173,
-        "narHash": "sha256-Gf1dFYgD344WZ3q0LPlRoWaNdNQq8kSBDLEWulRQSEs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "13b0f9e6ac78abbbb736c635d87845c4f4bee51b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
         "lastModified": 1777428379,
         "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
         "owner": "NixOS",
@@ -882,7 +840,7 @@
         "impermanence": "impermanence",
         "kryptonix": "kryptonix",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs",
         "systems": "systems",
         "unstable": "unstable"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -883,7 +883,8 @@
         "kryptonix": "kryptonix",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_4",
-        "systems": "systems"
+        "systems": "systems",
+        "unstable": "unstable"
       }
     },
     "rust-overlay": {
@@ -941,6 +942,22 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "unstable": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,12 @@
   };
   inputs = {
     devenv = {
-      inputs.nixpkgs.follows = "nixpkgs";
+      inputs = {
+        crate2nix.inputs.cachix.inputs.nixpkgs.follows = "nixpkgs";
+        crate2nix.inputs.crate2nix_stable.inputs.cachix.inputs.nixpkgs.follows = "nixpkgs";
+        crate2nix.inputs.crate2nix_stable.inputs.nixpkgs.follows = "nixpkgs";
+        nixpkgs.follows = "nixpkgs";
+      };
       url = "github:cachix/devenv";
     };
     agenix = {

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     nixos-hardware.url = "github:NixOS/nixos-hardware";
     systems.url = "github:nix-systems/default";
+    unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
   outputs =
     inputs@{

--- a/nixosModules/claude.nix
+++ b/nixosModules/claude.nix
@@ -6,7 +6,8 @@
 }:
 let
   inherit (lib) mkEnableOption mkIf;
-  inherit (pkgs) claude-code gh;
+  inherit (pkgs) gh;
+  inherit (pkgs.unstable) claude-code;
   cfg = config.thoughtfull.claude;
 in
 {

--- a/nixosModules/default.nix
+++ b/nixosModules/default.nix
@@ -98,6 +98,7 @@ in
     overlays = [
       self.overlays.emacs
       self.overlays.thoughtfull
+      self.overlays.unstable
     ];
   };
 }

--- a/overlays.nix
+++ b/overlays.nix
@@ -1,4 +1,5 @@
 self: {
   emacs = import ./overlays/emacs.nix self;
   thoughtfull = import ./overlays/thoughtfull.nix self;
+  unstable = import ./overlays/unstable.nix self;
 }

--- a/overlays/unstable.nix
+++ b/overlays/unstable.nix
@@ -1,0 +1,6 @@
+self: _final: prev: {
+  unstable = import self.inputs.unstable {
+    inherit (prev.stdenv.hostPlatform) system;
+    config = prev.config;
+  };
+}


### PR DESCRIPTION
## Summary
- Expose nixos-unstable as `pkgs.unstable` in NixOS modules via a new overlay
- Switch `claude-code` to pull from `pkgs.unstable`
- Collapse three duplicate nixpkgs revisions that devenv's `crate2nix` transitive dep was pulling in, leaving just the root `nixpkgs` and the new `unstable` in the lock file

Closes #142