### PR TITLE
Fetch private flakes via GitHub PAT and enable auto-upgrades

### DIFF
--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -15,6 +15,8 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |
+            trusted-users = root runner
+            accept-flake-config = true
             access-tokens = github.com=${{ secrets.KRYPTONIX_ACCESS_TOKEN }}
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main

--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -13,12 +13,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            access-tokens = github.com=${{ secrets.KRYPTONIX_ACCESS_TOKEN }}
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
-      - name: Setup SSH for private flake inputs
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.KRYPTONIX_DEPLOY_KEY }}
       - name: Run devenv test
         run: nix develop --no-pure-eval --command devenv test
       - name: Run flake check

--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           extra-conf: |
             trusted-users = root runner
-            accept-flake-config = true
             access-tokens = github.com=${{ secrets.KRYPTONIX_ACCESS_TOKEN }}
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,6 +21,8 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |
+            trusted-users = root runner
+            accept-flake-config = true
             access-tokens = github.com=${{ secrets.KRYPTONIX_ACCESS_TOKEN }}
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,12 +19,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            access-tokens = github.com=${{ secrets.KRYPTONIX_ACCESS_TOKEN }}
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
-      - name: Setup SSH for private flake inputs
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.KRYPTONIX_DEPLOY_KEY }}
       - name: Build options-doc
         run: nix build .#options-doc
       - name: Upload artifact

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           extra-conf: |
             trusted-users = root runner
-            accept-flake-config = true
             access-tokens = github.com=${{ secrets.KRYPTONIX_ACCESS_TOKEN }}
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main

--- a/flake.lock
+++ b/flake.lock
@@ -632,16 +632,16 @@
       "locked": {
         "lastModified": 1778716311,
         "narHash": "sha256-f41/+33XmbrgACc4nHucgbxSq62o/ZxtBDF7NdukFM4=",
-        "ref": "sedna",
+        "owner": "technosophist",
+        "repo": "kryptonix",
         "rev": "9cc5536c19e826f810ac4ba527b5888b6b047922",
-        "revCount": 13,
-        "type": "git",
-        "url": "ssh://git@github.com/technosophist/kryptonix"
+        "type": "github"
       },
       "original": {
+        "owner": "technosophist",
         "ref": "sedna",
-        "type": "git",
-        "url": "ssh://git@github.com/technosophist/kryptonix"
+        "repo": "kryptonix",
+        "type": "github"
       }
     },
     "nix": {

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
       };
       url = "github:nix-community/impermanence";
     };
-    kryptonix.url = "git+ssh://git@github.com/technosophist/kryptonix?ref=sedna";
+    kryptonix.url = "github:technosophist/kryptonix?ref=sedna";
     nixos-hardware.url = "github:NixOS/nixos-hardware";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     systems.url = "github:nix-systems/default";

--- a/nixosConfigurations/shared/secrets/github-access-token.age
+++ b/nixosConfigurations/shared/secrets/github-access-token.age
@@ -1,0 +1,13 @@
+age-encryption.org/v1
+-> piv-p256 2ONmvQ Ah1vuEx/duRFFtnDj6IffxnRKl1knzn8W4AYT0/gmjZZ
+VgqEumij69WwEoUS6JQuYdIWHKe8u47ViQaJNUpFkyE
+-> piv-p256 5HigPA ArQUorBT5vOJTd8q5kYAxxnSDi9vNS5FIJWPU+gIMVdV
+oblZ8iqdQcUzveOAId/fY/FC0acWh9GtINNtdlafcME
+-> ssh-ed25519 3ZqDMA L1Li1PcCwobJoJweiwkYKoYb3nxmypPNpH0GMy4WfT0
+Nmhqo5PjzfCIUeiuTJSRYQBw057BDw2PyhB2SNrWFZg
+-> ssh-ed25519 x9AsDg hcXYq2PGP55vPB27e11osLlHgmfpnqmSa7Wh96T1MW8
+P3ocV3dtl7EmOSucedo7KFjcKgg/5QSCuNnyiFx+/qs
+--- 7G5X2GB5wZ7PavMGE/CIN5OGMC4a3EOgWdLwROynPYw
+µÛX}
+
+ÜrúÉÓÒŸk1#áu¤kEpÅqiGtÚqìC½m–Šíø@½‡¨=ŽyóbIGŠhNFµÄ&ƒM.säkáJ}î4fWÎM"gÜ;j-¸£¸‰¶f#f´e\×}fí‹—ƒ÷Ú^d"ÏFÏ[¼uB|âÔ‡s/¨ÌòãD°Ì&kïZ~O“jÊO+²

--- a/nixosModules/auto-upgrade.nix
+++ b/nixosModules/auto-upgrade.nix
@@ -1,0 +1,16 @@
+{ config, lib, ... }:
+let
+  inherit (config.thoughtfull) graphical;
+  inherit (lib) mkDefault;
+in
+{
+  system.autoUpgrade = {
+    enable = mkDefault true;
+    flake = mkDefault "github:thoughtfull-nix/nixfiles";
+    dates = mkDefault (if graphical.enable then "*-*-* 12:00:00" else "*-*-* 03:00:00");
+    randomizedDelaySec = mkDefault "15min";
+    # Headless hosts may reboot for kernel updates; graphical hosts stage the
+    # new kernel and apply it on the user's next manual reboot.
+    allowReboot = mkDefault (!graphical.enable);
+  };
+}

--- a/nixosModules/default.nix
+++ b/nixosModules/default.nix
@@ -37,6 +37,7 @@ in
     # use a directory with the same name as the module (e.g. './foo.nix' should use files in
     # './foo/').
     ./agenix.nix
+    ./auto-upgrade.nix
     ./avahi.nix
     ./backlight.nix
     ./bluetooth.nix
@@ -53,6 +54,7 @@ in
     ./foot.nix
     ./fuzzel.nix
     ./git.nix
+    ./github-token.nix
     ./gnupg.nix
     ./graphical.nix
     ./gtklock.nix

--- a/nixosModules/github-token.nix
+++ b/nixosModules/github-token.nix
@@ -1,0 +1,47 @@
+# Future direction: build-and-push instead of fetch-and-build.
+#
+# At a larger scale (or to keep private source off the hosts entirely), run
+# `nixos-rebuild` on a single trusted builder that has read access to
+# kryptonix, sign the resulting system closure, push it to a binary cache,
+# and have each host `nix copy` + `switch-to-configuration` from the
+# substituter. Hosts never fetch private source and need no token. This is
+# the model used by Cachix Deploy / `colmena push` / `deploy-rs`. Bigger
+# architectural shift, much cleaner blast radius — worth revisiting if the
+# fleet grows past a handful of machines.
+{ config, lib, ... }:
+let
+  inherit (config.thoughtfull) githubToken;
+  inherit (lib) mkIf mkOption types;
+in
+{
+  config = mkIf (githubToken.tokenFile != null) {
+    age.secrets.github-access-token.file = githubToken.tokenFile;
+    nix.extraOptions = ''
+      !include ${config.age.secrets.github-access-token.path}
+    '';
+  };
+
+  options.thoughtfull.githubToken = {
+    tokenFile = mkOption {
+      default = ../nixosConfigurations/shared/secrets/github-access-token.age;
+      description = ''
+        Path to an age-encrypted file whose plaintext is a single nix.conf
+        line such as `access-tokens = github.com=ghp_xxxxxxxxxxxxxxxxxxxx`.
+
+        The file is decrypted by agenix at activation time and `!include`d
+        into nix.conf, so the nix daemon can fetch private GitHub flake
+        inputs (e.g. via the `github:owner/repo` URL scheme) without an SSH
+        agent.
+
+        Set to `null` to disable.
+
+        Bootstrap: a freshly provisioned host has no decrypted token before
+        its first `nixos-rebuild`, so the initial install of a host that
+        uses private inputs still needs the token in the operator's
+        environment (`--option access-tokens 'github.com=…'` or
+        `~/.config/nix/nix.conf`).
+      '';
+      type = types.nullOr types.path;
+    };
+  };
+}

--- a/tests.nix
+++ b/tests.nix
@@ -13,7 +13,9 @@ forEachSystem (
     callTest = path: import path { inherit self nixpkgs; };
   in
   {
+    auto-upgrade = callTest ./tests/auto-upgrade.nix;
     avahi = callTest ./tests/avahi.nix;
+    github-token = callTest ./tests/github-token.nix;
     waybar = callTest ./tests/waybar.nix;
   }
 )

--- a/tests/auto-upgrade.nix
+++ b/tests/auto-upgrade.nix
@@ -1,0 +1,117 @@
+{ nixpkgs, ... }:
+let
+  # Stub thoughtfull.graphical.enable so the auto-upgrade module can branch on
+  # it without pulling in nixosModules/graphical.nix (which depends on other
+  # internal modules like impermanence).
+  graphicalStub =
+    { lib, ... }:
+    {
+      options.thoughtfull.graphical.enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+      };
+    };
+in
+nixpkgs.testers.nixosTest {
+  name = "auto-upgrade";
+
+  skipTypeCheck = true;
+  skipLint = true;
+
+  nodes = {
+    graphical = {
+      imports = [
+        ../nixosModules/auto-upgrade.nix
+        graphicalStub
+      ];
+      thoughtfull.graphical.enable = true;
+    };
+
+    headless = {
+      imports = [
+        ../nixosModules/auto-upgrade.nix
+        graphicalStub
+      ];
+      # graphical.enable stays false
+    };
+
+    optout =
+      { lib, ... }:
+      {
+        imports = [
+          ../nixosModules/auto-upgrade.nix
+          graphicalStub
+        ];
+        system.autoUpgrade.enable = lib.mkForce false;
+      };
+  };
+
+  testScript = ''
+    import re
+
+    def upgrade_script(machine):
+        # NixOS encodes `script = "..."` services as a wrapper executable at
+        # the ExecStart path. The actual `nixos-rebuild` invocation lives in
+        # that file, not in the unit text.
+        unit = machine.succeed("systemctl cat nixos-upgrade.service")
+        m = re.search(r"^ExecStart=(\S+)", unit, re.MULTILINE)
+        assert m, f"could not parse ExecStart from unit:\n{unit}"
+        return machine.succeed(f"cat {m.group(1)}")
+
+    start_all()
+    graphical.wait_for_unit("multi-user.target")
+    headless.wait_for_unit("multi-user.target")
+    optout.wait_for_unit("multi-user.target")
+
+    with subtest("graphical default: timer fires at noon"):
+        timer = graphical.succeed("systemctl cat nixos-upgrade.timer")
+        print(f"graphical timer:\n{timer}")
+        assert "OnCalendar=*-*-* 12:00:00" in timer, (
+            "graphical host should fire at noon"
+        )
+        assert "RandomizedDelaySec=15min" in timer, (
+            "should have 15min randomized delay"
+        )
+
+    with subtest("graphical default: does not allow reboot"):
+        script = upgrade_script(graphical)
+        print(f"graphical script:\n{script}")
+        # When allowReboot=false, upstream emits `nixos-rebuild switch ...`
+        # directly and never invokes `shutdown -r`.
+        assert "shutdown -r" not in script, (
+            "graphical host must not schedule a reboot"
+        )
+        assert "nixos-rebuild boot" not in script, (
+            "graphical host should use 'switch', not 'boot'"
+        )
+
+    with subtest("headless default: timer fires at 3am"):
+        timer = headless.succeed("systemctl cat nixos-upgrade.timer")
+        print(f"headless timer:\n{timer}")
+        assert "OnCalendar=*-*-* 03:00:00" in timer, (
+            "headless host should fire at 3am"
+        )
+
+    with subtest("headless default: allows reboot"):
+        script = upgrade_script(headless)
+        print(f"headless script:\n{script}")
+        # When allowReboot=true, upstream's script first does `nixos-rebuild
+        # boot ...` and conditionally `shutdown -r +1`.
+        assert "nixos-rebuild boot" in script, (
+            "headless host should use 'boot' to stage kernel updates"
+        )
+        assert "shutdown -r" in script, (
+            "headless host should schedule a reboot when kernel changed"
+        )
+
+    with subtest("default flake URL points to thoughtfull-nix/nixfiles"):
+        script = upgrade_script(graphical)
+        assert "--flake github:thoughtfull-nix/nixfiles" in script, (
+            "default flake should be github:thoughtfull-nix/nixfiles"
+        )
+
+    with subtest("opt-out: timer and service do not exist"):
+        optout.fail("systemctl cat nixos-upgrade.timer")
+        optout.fail("systemctl cat nixos-upgrade.service")
+  '';
+}

--- a/tests/github-token.nix
+++ b/tests/github-token.nix
@@ -1,0 +1,78 @@
+{ nixpkgs, ... }:
+let
+  # Stub the agenix `age.secrets` option so we can test the module's
+  # `nix.extraOptions` synthesis without actually pulling in the agenix
+  # activation scripts (which need a real SSH identity to decrypt).
+  ageSecretsStub =
+    { lib, ... }:
+    {
+      options.age.secrets = lib.mkOption {
+        default = { };
+        type = lib.types.attrsOf (
+          lib.types.submodule (
+            { name, ... }:
+            {
+              options = {
+                file = lib.mkOption { type = lib.types.path; };
+                path = lib.mkOption {
+                  type = lib.types.str;
+                  default = "/run/agenix/${name}";
+                };
+              };
+            }
+          )
+        );
+      };
+    };
+in
+nixpkgs.testers.nixosTest {
+  name = "github-token";
+
+  skipTypeCheck = true;
+  skipLint = true;
+
+  nodes = {
+    withToken =
+      { pkgs, ... }:
+      {
+        imports = [
+          ../nixosModules/github-token.nix
+          ageSecretsStub
+        ];
+        # Use a fake plaintext file instead of the real .age fixture so the
+        # test doesn't depend on the encrypted secret being decryptable.
+        thoughtfull.githubToken.tokenFile = pkgs.writeText "fake-token" "fake";
+      };
+
+    withoutToken = {
+      imports = [
+        ../nixosModules/github-token.nix
+        ageSecretsStub
+      ];
+      thoughtfull.githubToken.tokenFile = null;
+    };
+  };
+
+  testScript = ''
+    start_all()
+    withToken.wait_for_unit("multi-user.target")
+    withoutToken.wait_for_unit("multi-user.target")
+
+    with subtest("default: tokenFile set => nix.conf !includes the agenix path"):
+        nix_conf = withToken.succeed("cat /etc/nix/nix.conf")
+        print(f"withToken nix.conf:\n{nix_conf}")
+        assert "!include /run/agenix/github-access-token" in nix_conf, (
+            "nix.conf should !include the decrypted token file"
+        )
+
+    with subtest("tokenFile null: nix.conf has no !include line"):
+        nix_conf = withoutToken.succeed("cat /etc/nix/nix.conf")
+        print(f"withoutToken nix.conf:\n{nix_conf}")
+        assert "!include" not in nix_conf, (
+            "nix.conf should not contain !include when tokenFile is null"
+        )
+        assert "agenix" not in nix_conf, (
+            "nix.conf should not reference agenix paths when tokenFile is null"
+        )
+  '';
+}


### PR DESCRIPTION
## Summary

- Adds a `github-token.nix` module that stores a GitHub access token as an agenix secret (`nixosConfigurations/shared/secrets/github-access-token.age`) and `!include`s the decrypted file into `nix.conf`. The nix daemon can now fetch private flake inputs over the `github:` URL scheme without needing SSH.
- Switches `kryptonix.url` from `git+ssh://` to `github:technosophist/kryptonix?ref=sedna` (faster tarball API, no SSH agent on the build host).
- Adds an `auto-upgrade.nix` module that enables `system.autoUpgrade` on every host by default. Defaults split on `thoughtfull.graphical.enable`:
  - Graphical hosts: fire at `*-*-* 12:00:00`, `allowReboot = false` (stage the kernel for the user's next reboot).
  - Headless hosts: fire at `*-*-* 03:00:00`, `allowReboot = true` (reboot unattended for kernel updates).
  - All values are `mkDefault`, so hosts can override individual fields or disable entirely.
- Adds VM tests for both modules (`tests/github-token.nix`, `tests/auto-upgrade.nix`).

Closes #83.
Closes #87.

## Follow-ups
- Bootstrap: a freshly provisioned host still needs the token in the operator's environment (`~/.config/nix/nix.conf` or `--option access-tokens …`) before the first `nixos-rebuild`. Documented in the module's option description.
- A header comment in `nixosModules/github-token.nix` sketches a future build-and-push direction (build kryptonix-aware closures on a trusted builder, push to a signed binary cache, hosts never fetch private source) for when the fleet outgrows the PAT model.