### PR TITLE
Detach switch-to-configuration from system-pull.service

### DIFF
--- a/packages/system-pull.nix
+++ b/packages/system-pull.nix
@@ -7,6 +7,7 @@ let
     hostname-debian
     jq
     nix
+    systemd
     ;
   inherit (lib) writeFileScriptBin;
 in
@@ -20,6 +21,7 @@ writeFileScriptBin {
     nix_env = "${nix}/bin/nix-env";
     nix_store = "${nix}/bin/nix-store";
     readlink = "${coreutils}/bin/readlink";
+    systemd_run = "${systemd}/bin/systemd-run";
   };
   src = ./system-pull/system-pull.bash;
 }

--- a/packages/system-pull/system-pull.bash
+++ b/packages/system-pull/system-pull.bash
@@ -44,6 +44,17 @@ echo "system-pull: registering system profile generation"
 @nix_env@ -p /nix/var/nix/profiles/system --set "${target}"
 
 echo "system-pull: switching configuration"
-"${target}/bin/switch-to-configuration" switch
+# Run switch-to-configuration in a transient unit so the switch survives
+# activation-time stop/restart of system-pull.service itself.
+@systemd_run@ \
+  -E LOCALE_ARCHIVE \
+  --collect \
+  --no-ask-password \
+  --pipe \
+  --quiet \
+  --service-type=exec \
+  --unit=system-pull-switch-to-configuration \
+  -- \
+  "${target}/bin/switch-to-configuration" switch
 
 echo "system-pull: switched to ${target}"

--- a/tests/system-pull.nix
+++ b/tests/system-pull.nix
@@ -119,6 +119,31 @@ nixpkgs.testers.nixosTest {
             f"ExecStart should invoke system-pull with bucket and region; got:\n{unit}"
         )
 
+    with subtest("switch-to-configuration runs in a transient unit detached from system-pull.service"):
+        # The script must wrap switch-to-configuration with systemd-run so the
+        # switch survives activation-time stop of system-pull.service itself.
+        exec_start = headless.succeed(
+            "systemctl show system-pull.service -p ExecStart --value"
+        )
+        script_path = exec_start.split("argv[]=")[1].split()[0]
+        script = headless.succeed(f"cat {script_path}")
+        print(f"system-pull script:\n{script}")
+        # Strip comment lines so the ordering check isn't fooled by prose.
+        code = "\n".join(
+            line for line in script.splitlines() if not line.lstrip().startswith("#")
+        )
+        assert "systemd-run" in code, (
+            "system-pull must invoke switch-to-configuration via systemd-run "
+            "so activation can stop/restart system-pull.service without killing "
+            "the in-flight switch"
+        )
+        assert "switch-to-configuration" in code, (
+            "system-pull must invoke switch-to-configuration"
+        )
+        assert code.index("systemd-run") < code.index("switch-to-configuration"), (
+            "systemd-run must wrap the switch-to-configuration invocation"
+        )
+
     with subtest("nix.conf gets s3:// substituter and trusted public key"):
         nix_conf = headless.succeed("cat /etc/nix/nix.conf")
         print(f"headless nix.conf:\n{nix_conf}")


### PR DESCRIPTION
system-pull was running switch-to-configuration directly in its own systemd cgroup, so when activation stopped system-pull.service (its ExecStart store path changes on every rebuild), it killed the in-flight switch. restartIfChanged=false alone wasn't enough.

Wrap the switch in systemd-run --collect --pipe --service-type=exec so it runs in a transient unit, matching what nixos-rebuild itself does.