### PR TITLE
Add dev module and expand graphical module with shared defaults

### DIFF
--- a/nixosConfigurations/bootstrap.nix
+++ b/nixosConfigurations/bootstrap.nix
@@ -2,40 +2,22 @@
 {
   modules = [
     (
-      { pkgs, ... }:
+      { ... }:
       {
-        environment.systemPackages = [ pkgs.devenv ];
         imports = [
           ./BOOTSTRAP/hardware-configuration.nix
         ];
-        networking = {
-          domain = "thoughtfull.systems";
-          hostName = "BOOTSTRAP";
-          networkmanager.enable = true;
-        };
-        programs = {
-          firefox.enable = true;
-          git.enable = true;
-          sway.enable = true;
-          zsh.enable = true;
-        };
-        services = {
-          emacs.enable = true;
-          openssh.enable = true;
-          xremap.enable = true;
-        };
+        networking.hostName = "BOOTSTRAP";
         system.stateVersion = "25.11";
         thoughtfull = {
+          dev.enable = true;
           graphical.enable = true;
-          impermanence = {
-            disko.enable = true;
-            enable = true;
+          impermanence.disko = {
+            # boot.size = "1G";
+            # encrypted.device = "/dev/nvme0n1";
+            # swap.size = "64G";
           };
-          user = {
-            extraGroups = [ "wheel" ];
-            hashedPasswordFile = ./BOOTSTRAP/secrets/hashed-user-passphrase.age;
-            name = "technosophist";
-          };
+          user.hashedPasswordFile = ./BOOTSTRAP/secrets/hashed-user-passphrase.age;
         };
       }
     )

--- a/nixosConfigurations/hydor.nix
+++ b/nixosConfigurations/hydor.nix
@@ -2,28 +2,15 @@
 {
   modules = [
     (
-      { pkgs, ... }:
+      { ... }:
       {
-        environment.systemPackages = [ pkgs.devenv ];
+        boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
         imports = [
           ./hydor/hardware-configuration.nix
         ];
-        networking = {
-          domain = "thoughtfull.systems";
-          hostName = "hydor";
-          networkmanager.enable = true;
-        };
-        programs = {
-          firefox.enable = true;
-          git.enable = true;
-          sway.enable = true;
-          zsh.enable = true;
-        };
+        networking.hostName = "hydor";
         services = {
-          emacs.enable = true;
-          openssh.enable = true;
           syncthing = {
-            enable = true;
             settings.folders = {
               archive.enable = true;
               obsidian.enable = true;
@@ -33,35 +20,17 @@
             };
             thoughtfull.passwordFile = ./hydor/secrets/syncthing-passphrase.age;
           };
-          xremap.enable = true;
         };
         system.stateVersion = "25.11";
         thoughtfull = {
-          backlight.enable = true;
-          claude.enable = true;
-          clojure.enable = true;
+          dev.enable = true;
           graphical.enable = true;
-          impermanence = {
-            disko = {
-              # boot.size = "1G";
-              enable = true;
-              encrypted.device = "/dev/nvme0n1";
-              # swap.size = "64G";
-            };
-            enable = true;
+          impermanence.disko = {
+            # boot.size = "1G";
+            encrypted.device = "/dev/nvme0n1";
+            # swap.size = "64G";
           };
-          monitoring = {
-            enable = true;
-            services = [
-              "sshd"
-              "syncthing"
-              "restic-backups-default"
-            ];
-          };
-          user = {
-            extraGroups = [ "wheel" ];
-            hashedPasswordFile = ./hydor/secrets/hashed-user-passphrase.age;
-          };
+          user.hashedPasswordFile = ./hydor/secrets/hashed-user-passphrase.age;
         };
       }
     )

--- a/nixosConfigurations/sedna.nix
+++ b/nixosConfigurations/sedna.nix
@@ -8,6 +8,7 @@
           ./sedna/hardware-configuration.nix
         ];
         networking.hostName = "sedna";
+        services.syncthing.thoughtfull.passwordFile = ./sedna/secrets/syncthing-passphrase.age;
         system.stateVersion = "25.05";
         thoughtfull = {
           dev.enable = true;

--- a/nixosConfigurations/sedna.nix
+++ b/nixosConfigurations/sedna.nix
@@ -2,86 +2,26 @@
 {
   modules = [
     (
-      { pkgs, ... }:
+      { ... }:
       {
-        boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
-        environment.systemPackages = [
-          pkgs.devenv
-        ]
-        ++ (with pkgs.thoughtfull; [
-          nixfiles
-          pins
-          uns
-        ]);
-        hardware.bluetooth.enable = true;
         imports = [
           ./sedna/hardware-configuration.nix
         ];
-        networking = {
-          domain = "thoughtfull.systems";
-          hostName = "sedna";
-          # useDHCP = true;
-          # wireless = {
-          #   enable = true;
-          #   userControlled.enable = true;
-          # };
-          networkmanager.enable = true;
-        };
-        programs = {
-          firefox.enable = true;
-          git.enable = true;
-          java.package = pkgs.javaPackages.compiler.temurin-bin.jdk-25;
-          sway.enable = true;
-          zsh.enable = true;
-        };
-        services = {
-          emacs.enable = true;
-          openssh.enable = true;
-          restic.thoughtfull.enable = true;
-          syncthing = {
-            enable = true;
-            thoughtfull.passwordFile = ./sedna/secrets/syncthing-passphrase.age;
-          };
-          xremap.enable = true;
-        };
+        networking.hostName = "sedna";
         system.stateVersion = "25.05";
-        systemd.user.services.mako.enable = true;
         thoughtfull = {
-          backlight.enable = true;
-          claude.enable = true;
-          clojure = {
-            enable = true;
-            # jdk.package = pkgs.javaPackages.compiler.temurin-bin.jdk-17;
-          };
+          dev.enable = true;
           graphical.enable = true;
-          impermanence = {
-            disko = {
-              boot.size = "1G";
-              enable = true;
-              encrypted.device = "/dev/nvme0n1";
-              swap.size = "64G";
-            };
-            enable = true;
+          impermanence.disko = {
+            boot.size = "1G";
+            encrypted.device = "/dev/nvme0n1";
+            swap.size = "64G";
           };
-          monitoring = {
-            enable = true;
-            services = [
-              "sshd"
-              "syncthing"
-              "restic-backups-default"
-              "mako"
-              "test-failure"
-            ];
-          };
-          programs = {
-            dictation.enable = true;
-            obsidian.enable = true;
-          };
-          rust.enable = true;
-          user = {
-            extraGroups = [ "wheel" ];
-            hashedPasswordFile = ./sedna/secrets/hashed-user-passphrase.age;
-          };
+          monitoring.services = [
+            "mako"
+            "test-failure"
+          ];
+          user.hashedPasswordFile = ./sedna/secrets/hashed-user-passphrase.age;
         };
       }
     )

--- a/nixosModules/default.nix
+++ b/nixosModules/default.nix
@@ -45,6 +45,7 @@ in
     ./boot.nix
     ./claude.nix
     ./clojure.nix
+    ./dev.nix
     ./dictation.nix
     ./discord.nix
     ./docker.nix

--- a/nixosModules/dev.nix
+++ b/nixosModules/dev.nix
@@ -1,0 +1,26 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (config.thoughtfull) dev;
+  inherit (lib) mkDefault mkEnableOption mkIf;
+  inherit (pkgs) devenv;
+in
+{
+  config = mkIf dev.enable {
+    environment.systemPackages = [ devenv ];
+    programs = {
+      git.enable = mkDefault true;
+      java.package = mkDefault pkgs.javaPackages.compiler.temurin-bin.jdk-25;
+    };
+    thoughtfull = {
+      claude.enable = mkDefault true;
+      clojure.enable = mkDefault true;
+      rust.enable = mkDefault true;
+    };
+  };
+  options.thoughtfull.dev.enable = mkEnableOption "development configuration";
+}

--- a/nixosModules/graphical.nix
+++ b/nixosModules/graphical.nix
@@ -1,12 +1,63 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   inherit (config.thoughtfull) graphical;
   inherit (lib) mkDefault mkEnableOption mkIf;
+  inherit (pkgs) gh;
+  inherit (pkgs.thoughtfull) nixfiles pins uns;
 in
 {
-  config = {
-    gtk.iconCache.enable = mkDefault graphical.enable;
-    thoughtfull.impermanence.user.directories = mkIf graphical.enable [ ".config/dconf" ];
+  config = mkIf graphical.enable {
+    environment.systemPackages = [
+      gh
+      nixfiles
+      pins
+      uns
+    ];
+    gtk.iconCache.enable = mkDefault true;
+    hardware.bluetooth.enable = true;
+    networking = {
+      domain = "thoughtfull.systems";
+      networkmanager.enable = true;
+    };
+    programs = {
+      firefox.enable = mkDefault true;
+      sway.enable = mkDefault true;
+      zsh.enable = mkDefault true;
+    };
+    services = {
+      emacs.enable = mkDefault true;
+      openssh.enable = mkDefault true;
+      restic.thoughtfull.enable = mkDefault true;
+      syncthing.enable = mkDefault true;
+      xremap.enable = mkDefault true;
+    };
+    systemd.user.services.mako.enable = true;
+    thoughtfull = {
+      backlight.enable = mkDefault true;
+      impermanence = {
+        disko.enable = mkDefault true;
+        enable = mkDefault true;
+        user.directories = [ ".config/dconf" ];
+      };
+      monitoring = {
+        enable = mkDefault true;
+        services = [
+          "sshd"
+          "syncthing"
+          "restic-backups-default"
+        ];
+      };
+      programs = {
+        dictation.enable = mkDefault true;
+        obsidian.enable = mkDefault true;
+      };
+      user.extraGroups = [ "wheel" ];
+    };
   };
   options.thoughtfull.graphical.enable = mkEnableOption "graphical UI configuration";
 }

--- a/nixosModules/graphical.nix
+++ b/nixosModules/graphical.nix
@@ -19,10 +19,10 @@ in
       uns
     ];
     gtk.iconCache.enable = mkDefault true;
-    hardware.bluetooth.enable = true;
+    hardware.bluetooth.enable = mkDefault true;
     networking = {
-      domain = "thoughtfull.systems";
-      networkmanager.enable = true;
+      domain = mkDefault "thoughtfull.systems";
+      networkmanager.enable = mkDefault true;
     };
     programs = {
       firefox.enable = mkDefault true;
@@ -36,7 +36,7 @@ in
       syncthing.enable = mkDefault true;
       xremap.enable = mkDefault true;
     };
-    systemd.user.services.mako.enable = true;
+    systemd.user.services.mako.enable = mkDefault true;
     thoughtfull = {
       backlight.enable = mkDefault true;
       impermanence = {

--- a/nixosModules/syncthing.nix
+++ b/nixosModules/syncthing.nix
@@ -29,6 +29,12 @@ let
 in
 {
   config = {
+    assertions = [
+      {
+        assertion = !syncthing.enable || passwordFile != null;
+        message = "services.syncthing.thoughtfull.passwordFile must be set when syncthing is enabled";
+      }
+    ];
     age.secrets = mkIf syncthing.enable {
       syncthing-cert = mkIf hasCert {
         file = certFile;

--- a/tests.nix
+++ b/tests.nix
@@ -15,7 +15,9 @@ forEachSystem (
   {
     auto-upgrade = callTest ./tests/auto-upgrade.nix;
     avahi = callTest ./tests/avahi.nix;
+    dev = callTest ./tests/dev.nix;
     github-token = callTest ./tests/github-token.nix;
+    graphical = callTest ./tests/graphical.nix;
     system-pull = callTest ./tests/system-pull.nix;
     waybar = callTest ./tests/waybar.nix;
   }

--- a/tests/dev.nix
+++ b/tests/dev.nix
@@ -1,0 +1,51 @@
+{ nixpkgs, ... }:
+let
+  # Stub the thoughtfull sub-module options that dev.nix sets via mkDefault
+  thoughtfullSubModuleStub =
+    { lib, ... }:
+    {
+      options.thoughtfull = {
+        claude.enable = lib.mkEnableOption "claude (stub)";
+        clojure.enable = lib.mkEnableOption "clojure (stub)";
+        rust.enable = lib.mkEnableOption "rust (stub)";
+      };
+    };
+in
+nixpkgs.testers.nixosTest {
+  name = "dev";
+
+  skipTypeCheck = true;
+  skipLint = true;
+
+  nodes = {
+    enabled = {
+      imports = [
+        ../nixosModules/dev.nix
+        thoughtfullSubModuleStub
+      ];
+      thoughtfull.dev.enable = true;
+    };
+
+    disabled = {
+      imports = [
+        ../nixosModules/dev.nix
+        thoughtfullSubModuleStub
+      ];
+    };
+  };
+
+  testScript = ''
+    start_all()
+    enabled.wait_for_unit("multi-user.target")
+    disabled.wait_for_unit("multi-user.target")
+
+    with subtest("enabled: devenv is in PATH"):
+        enabled.succeed("which devenv")
+
+    with subtest("enabled: git is in PATH"):
+        enabled.succeed("which git")
+
+    with subtest("disabled default: devenv is not available"):
+        disabled.fail("which devenv")
+  '';
+}

--- a/tests/dev.nix
+++ b/tests/dev.nix
@@ -24,6 +24,9 @@ nixpkgs.testers.nixosTest {
         thoughtfullSubModuleStub
       ];
       thoughtfull.dev.enable = true;
+      # nixosModules/java.nix sets programs.java.enable = mkDefault true in the
+      # full system; mirror that here so the package selection is exercised.
+      programs.java.enable = true;
     };
 
     disabled = {
@@ -44,6 +47,11 @@ nixpkgs.testers.nixosTest {
 
     with subtest("enabled: git is in PATH"):
         enabled.succeed("which git")
+
+    with subtest("enabled: java is in PATH and is JDK 25"):
+        result = enabled.succeed("java -version 2>&1")
+        print(f"java -version: {result}")
+        assert "25" in result, f"expected JDK 25 (temurin-bin.jdk-25), got: {result}"
 
     with subtest("disabled default: devenv is not available"):
         disabled.fail("which devenv")

--- a/tests/graphical.nix
+++ b/tests/graphical.nix
@@ -1,0 +1,100 @@
+{ nixpkgs, self, ... }:
+let
+  overlayModule = {
+    nixpkgs.overlays = [ self.overlays.thoughtfull ];
+  };
+
+  # Stub options defined in other thoughtfull modules that graphical.nix sets via mkDefault
+  graphicalDepsStub =
+    { lib, ... }:
+    {
+      options = {
+        services.restic.thoughtfull.enable = lib.mkEnableOption "restic (stub)";
+        services.xremap.enable = lib.mkEnableOption "xremap (stub)";
+        thoughtfull = {
+          backlight.enable = lib.mkEnableOption "backlight (stub)";
+          impermanence = {
+            disko.enable = lib.mkEnableOption "impermanence disko (stub)";
+            enable = lib.mkEnableOption "impermanence (stub)";
+            user.directories = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+            };
+          };
+          monitoring = {
+            enable = lib.mkEnableOption "monitoring (stub)";
+            services = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+            };
+          };
+          programs = {
+            dictation.enable = lib.mkEnableOption "dictation (stub)";
+            obsidian.enable = lib.mkEnableOption "obsidian (stub)";
+          };
+          user.extraGroups = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [ ];
+          };
+        };
+      };
+    };
+
+  imports = [
+    ../nixosModules/graphical.nix
+    graphicalDepsStub
+    overlayModule
+  ];
+in
+nixpkgs.testers.nixosTest {
+  name = "graphical";
+
+  skipTypeCheck = true;
+  skipLint = true;
+
+  nodes = {
+    enabled =
+      { lib, ... }:
+      {
+        inherit imports;
+        thoughtfull.graphical.enable = true;
+        # Disable heavy services to keep the test VM lightweight
+        hardware.bluetooth.enable = lib.mkForce false;
+        programs.firefox.enable = lib.mkForce false;
+        programs.sway.enable = lib.mkForce false;
+        services.emacs.enable = lib.mkForce false;
+        services.syncthing.enable = lib.mkForce false;
+      };
+
+    disabled = {
+      inherit imports;
+      # thoughtfull.graphical.enable defaults to false
+    };
+  };
+
+  testScript = ''
+    start_all()
+    enabled.wait_for_unit("multi-user.target")
+    disabled.wait_for_unit("multi-user.target")
+
+    with subtest("graphical enabled: gh is in PATH"):
+        enabled.succeed("which gh")
+
+    with subtest("graphical enabled: NetworkManager is configured"):
+        enabled.succeed("systemctl cat NetworkManager.service")
+
+    with subtest("graphical enabled: sshd is running"):
+        enabled.wait_for_unit("sshd.service")
+
+    with subtest("graphical enabled: networking domain is set"):
+        hosts = enabled.succeed("cat /etc/hosts")
+        print(f"/etc/hosts:\n{hosts}")
+        assert "thoughtfull.systems" in hosts, "networking.domain should appear in /etc/hosts"
+
+    with subtest("graphical disabled: gh is not in PATH"):
+        disabled.fail("which gh")
+
+    with subtest("graphical disabled: NetworkManager is not configured"):
+        disabled.fail("systemctl cat NetworkManager.service")
+  '';
+}


### PR DESCRIPTION
## Summary

- Adds `thoughtfull.dev.enable` module consolidating common development dependencies (devenv, git, java, claude, clojure, rust) that were previously duplicated across host configurations
- Expands `thoughtfull.graphical.enable` to set shared graphical host defaults (networking domain/NetworkManager, packages gh/nixfiles/pins/uns, services openssh/syncthing/emacs/xremap, impermanence, monitoring) so individual host configs only override what's unique to them
- Simplifies bootstrap, hydor, and sedna host configurations to use the new shared modules
- Adds NixOS VM tests for both `dev` and `graphical` modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)