### PR TITLE
Remove defaults from disko and syncthing required options

### DIFF
--- a/nixosConfigurations/bootstrap.nix
+++ b/nixosConfigurations/bootstrap.nix
@@ -13,9 +13,9 @@
           dev.enable = true;
           graphical.enable = true;
           impermanence.disko = {
-            # boot.size = "1G";
+            # boot.size = "512M";
             # encrypted.device = "/dev/nvme0n1";
-            # swap.size = "64G";
+            # swap.size = "4G";
           };
           user.hashedPasswordFile = ./BOOTSTRAP/secrets/hashed-user-passphrase.age;
         };

--- a/nixosConfigurations/bootstrap.nix
+++ b/nixosConfigurations/bootstrap.nix
@@ -13,7 +13,7 @@
           dev.enable = true;
           graphical.enable = true;
           impermanence.disko = {
-            # boot.size = "512M";
+            # boot.size = "1G";
             # encrypted.device = "/dev/nvme0n1";
             # swap.size = "4G";
           };

--- a/nixosConfigurations/hydor.nix
+++ b/nixosConfigurations/hydor.nix
@@ -26,9 +26,9 @@
           dev.enable = true;
           graphical.enable = true;
           impermanence.disko = {
-            # boot.size = "1G";
+            boot.size = "512M";
             encrypted.device = "/dev/nvme0n1";
-            # swap.size = "64G";
+            swap.size = "4G";
           };
           user.hashedPasswordFile = ./hydor/secrets/hashed-user-passphrase.age;
         };

--- a/nixosModules/impermanence.nix
+++ b/nixosModules/impermanence.nix
@@ -64,6 +64,7 @@ in
           type = types.listOf types.str;
         };
         size = mkOption {
+          description = "Size of the EFI system partition. Use 1G for a laptop or desktop; 512M if space is tight.";
           type = types.str;
         };
       };
@@ -71,6 +72,7 @@ in
         default = impermanence.enable;
       };
       encrypted.device = mkOption {
+        description = "Block device to partition and encrypt. Run `lsblk` or `ls /dev/disk/by-id/` to identify the target drive, e.g. \"/dev/nvme0n1\".";
         type = types.str;
       };
       nix.mountOptions = mkOption {
@@ -120,6 +122,7 @@ in
         };
       };
       swap.size = mkOption {
+        description = "Size of the swap file. Match RAM size to support hibernation (suspend-to-disk); half RAM is sufficient for suspend-to-RAM only. E.g. \"64G\" for a 64 GB machine that needs hibernation.";
         type = types.str;
       };
     };

--- a/nixosModules/impermanence.nix
+++ b/nixosModules/impermanence.nix
@@ -64,7 +64,6 @@ in
           type = types.listOf types.str;
         };
         size = mkOption {
-          default = "512M";
           type = types.str;
         };
       };
@@ -72,8 +71,7 @@ in
         default = impermanence.enable;
       };
       encrypted.device = mkOption {
-        default = null;
-        type = types.nullOr types.str;
+        type = types.str;
       };
       nix.mountOptions = mkOption {
         default = [
@@ -122,7 +120,6 @@ in
         };
       };
       swap.size = mkOption {
-        default = "4G";
         type = types.str;
       };
     };

--- a/nixosModules/impermanence/gpt.nix
+++ b/nixosModules/impermanence/gpt.nix
@@ -17,12 +17,6 @@ let
     ;
 in
 {
-  assertions = [
-    {
-      assertion = !enable || encrypted.device != null;
-      message = "thoughtfull.impermanence.disko.encrypted.device is not configured";
-    }
-  ];
   disko.devices.disk.main = mkIf enable {
     content = {
       partitions = {

--- a/nixosModules/syncthing.nix
+++ b/nixosModules/syncthing.nix
@@ -172,6 +172,7 @@ in
       type = types.nullOr types.path;
     };
     passwordFile = mkOption {
+      description = "Age-encrypted file whose plaintext content is the Syncthing GUI password. Create with `nixfiles secret <HOST> syncthing-passphrase`.";
       type = types.path;
     };
   };

--- a/nixosModules/syncthing.nix
+++ b/nixosModules/syncthing.nix
@@ -29,12 +29,6 @@ let
 in
 {
   config = {
-    assertions = [
-      {
-        assertion = !syncthing.enable || passwordFile != null;
-        message = "services.syncthing.thoughtfull.passwordFile must be set when syncthing is enabled";
-      }
-    ];
     age.secrets = mkIf syncthing.enable {
       syncthing-cert = mkIf hasCert {
         file = certFile;
@@ -178,8 +172,7 @@ in
       type = types.nullOr types.path;
     };
     passwordFile = mkOption {
-      default = null;
-      type = types.nullOr types.path;
+      type = types.path;
     };
   };
 }


### PR DESCRIPTION
## Summary

- `thoughtfull.impermanence.disko.boot.size`, `.encrypted.device`, and `.swap.size` no longer have defaults — evaluation fails with "has no default value" if unset when disko is enabled
- `services.syncthing.thoughtfull.passwordFile` similarly loses its `null` default
- Removed explicit assertions that are now redundant
- `hydor` gets explicit values for `boot.size` and `swap.size` (the former defaults)
- `bootstrap.nix` comments updated to show the former defaults as a reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)