### PR TITLE
Bump nixpkgs to nixos-26.05, switch to claude-desktop-fhs

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           for attempt in 1 2 3; do
             if out=$(nix build --no-link --print-out-paths \
-              --override-input nixpkgs github:NixOS/nixpkgs/nixos-25.11 \
+              --override-input nixpkgs github:NixOS/nixpkgs/nixos-26.05 \
               ".#nixosConfigurations.${{ matrix.host }}.config.system.build.toplevel"); then
               echo "out=$out" >>"$GITHUB_OUTPUT"
               exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ nixfmt-rfc-style <file.nix>
 
 ## Architecture Overview
 
-This is a NixOS flake-based system configuration framework using nixpkgs 25.11 with these key integrations:
+This is a NixOS flake-based system configuration framework using nixpkgs 26.05 with these key integrations:
 - **agenix**: Secret management (encrypted files in repo)
 - **disko**: Declarative disk partitioning
 - **impermanence**: Stateless root filesystem with persistent `/persistent` mount

--- a/README.org
+++ b/README.org
@@ -3,6 +3,11 @@
 To install git hooks run:
 : devenv tasks run devenv:git-hooks:install
 
+If ~flake-checker~ is stale and complains about the ~nixpkgs~ version (e.g.
+rejecting a release branch it doesn't recognize yet), run:
+: devenv update
+: devenv tasks run devenv:git-hooks:install
+
 ** nixos
 An installation/rescue ISO file based on the NixOS installation ISO file, but preconfigured with my
 user accounts and modules.

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1776354588,
+        "lastModified": 1783538213,
+        "narHash": "sha256-jNjKlmrejUrBgVAeiavlMLlkmC7ZEv1D9nhfuwMW5Q8=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "d7aba90c41ee261d215cbe09cf92393cc0ff2606",
+        "rev": "d1fb321e73048d0e1e2b523580268ebb3df2ae90",
         "type": "github"
       },
       "original": {
@@ -20,6 +21,7 @@
       "flake": false,
       "locked": {
         "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "NixOS",
         "repo": "flake-compat",
         "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
@@ -34,50 +36,31 @@
     "git-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1775585728,
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1762808025,
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776169885,
+        "lastModified": 1783522502,
+        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
         "type": "github"
       },
       "original": {
@@ -91,10 +74,7 @@
       "inputs": {
         "devenv": "devenv",
         "git-hooks": "git-hooks",
-        "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": [
-          "git-hooks"
-        ]
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,6 +1,11 @@
 ---
 # yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
 inputs:
+  git-hooks:
+    url: github:cachix/git-hooks.nix
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
   nixpkgs:
     url: github:nixos/nixpkgs/nixos-unstable
 

--- a/doc/binary-cache.md
+++ b/doc/binary-cache.md
@@ -89,7 +89,7 @@ The public half is committed in cleartext as the default value of the
 1. GitHub Actions matrix triggers at 02:00 UTC (and on every push to `main`).
 2. Each matrix job builds
    `.#nixosConfigurations.<host>.config.system.build.toplevel`, with
-   `--override-input nixpkgs github:NixOS/nixpkgs/nixos-25.11` so the daily
+   `--override-input nixpkgs github:NixOS/nixpkgs/nixos-26.05` so the daily
    build picks up the latest tip of the release branch.
 3. The build step uses the S3 cache itself as an additional substituter
    (`extra-substituters` in the installer config), so already-pushed paths

--- a/flake.lock
+++ b/flake.lock
@@ -901,16 +901,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782847189,
-        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
+        "lastModified": 1783549019,
+        "narHash": "sha256-0XnckG4ZhBmAsYa9mLuEIFowBG0fDGPLHduQGsbMS4A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
+        "rev": "74cc63f702f7d60a557e152a57b40fb1fd0f72ac",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
       url = "github:numtide/llm-agents.nix";
     };
     nixos-hardware.url = "github:NixOS/nixos-hardware";
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     systems.url = "github:nix-systems/default";
     unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
   };

--- a/nixosModules/claude-desktop.nix
+++ b/nixosModules/claude-desktop.nix
@@ -11,7 +11,7 @@ in
 {
   config = mkIf cfg.enable {
     environment.systemPackages = with pkgs; [
-      claude-desktop
+      claude-desktop-fhs
     ];
     thoughtfull.impermanence.user.directories = [
       ".config/Claude"

--- a/packages/options-doc/default.nix
+++ b/packages/options-doc/default.nix
@@ -51,7 +51,7 @@ let
           }
         else if isNixpkgs then
           {
-            url = "https://github.com/NixOS/nixpkgs/blob/nixos-25.11/${relativePath}";
+            url = "https://github.com/NixOS/nixpkgs/blob/nixos-26.05/${relativePath}";
             source = "nixpkgs";
           }
         else

--- a/tests/avahi.nix
+++ b/tests/avahi.nix
@@ -21,8 +21,8 @@ nixpkgs.testers.nixosTest {
     start_all()
 
     # Wait for avahi-daemon to be running on both nodes
-    testserver.wait_for_unit("avahi-daemon.service")
-    testclient.wait_for_unit("avahi-daemon.service")
+    server.wait_for_unit("avahi-daemon.service")
+    client.wait_for_unit("avahi-daemon.service")
 
     # Wait for network to settle and allow mDNS to propagate
     import time
@@ -32,21 +32,21 @@ nixpkgs.testers.nixosTest {
     with subtest("default: NSS mDNS integration is enabled"):
         # Verify NSS mDNS integration works by using getent (uses NSS, not avahi directly)
         # This will only succeed if nssmdns4 is properly configured
-        result = testclient.succeed("getent hosts testserver.local", timeout=10)
+        result = client.succeed("getent hosts testserver.local", timeout=10)
         print(f"NSS lookup result: {result}")
         assert "testserver" in result.lower(), "NSS should resolve .local hostnames"
 
     with subtest("default: address publishing is enabled"):
         # Forward lookup should work
-        result = testclient.succeed("avahi-resolve -n testserver.local", timeout=10)
+        result = client.succeed("avahi-resolve -n testserver.local", timeout=10)
         print(f"Forward lookup result: {result}")
 
         # Get the IP address from forward lookup
-        server_ip = testclient.succeed("avahi-resolve -n testserver.local | awk '{print $2}'").strip()
+        server_ip = client.succeed("avahi-resolve -n testserver.local | awk '{print $2}'").strip()
         print(f"Server IP: {server_ip}")
 
         # Reverse lookup should work
-        reverse_result = testclient.succeed(f"avahi-resolve -a {server_ip}", timeout=10)
+        reverse_result = client.succeed(f"avahi-resolve -a {server_ip}", timeout=10)
         print(f"Reverse lookup result: {reverse_result}")
         assert "testserver.local" in reverse_result, "Reverse lookup should return hostname"
 
@@ -54,18 +54,18 @@ nixpkgs.testers.nixosTest {
         # Note: Domain publishing relates to wide-area DNS-SD domain announcements
         # and doesn't have an easily testable functional aspect via avahi-browse -D
         # (which shows "+  n/a  n/a" regardless). Verify the config setting instead.
-        config_path = testserver.succeed("systemctl cat avahi-daemon | grep ExecStart | sed 's/.*-f //;s/ .*//'").strip()
-        result = testserver.succeed(f"grep -E '^publish-domain=' {config_path}")
+        config_path = server.succeed("systemctl cat avahi-daemon | grep ExecStart | sed 's/.*-f //;s/ .*//'").strip()
+        result = server.succeed(f"grep -E '^publish-domain=' {config_path}")
         print(f"Domain publish config: {result}")
         assert "publish-domain=yes" in result, "publish-domain should be 'yes' by default"
 
     with subtest("default: basic avahi functionality"):
         # Check that avahi binaries are available
-        testserver.succeed("which avahi-browse")
-        testclient.succeed("which avahi-browse")
+        server.succeed("which avahi-browse")
+        client.succeed("which avahi-browse")
 
         # Test that avahi can browse services
-        testserver.succeed("avahi-browse -a -t", timeout=10)
-        testclient.succeed("avahi-browse -a -t", timeout=10)
+        server.succeed("avahi-browse -a -t", timeout=10)
+        client.succeed("avahi-browse -a -t", timeout=10)
   '';
 }


### PR DESCRIPTION
## Summary
- Bump nixpkgs input from nixos-25.11 to nixos-26.05 (flake.nix, flake.lock, CLAUDE.md, doc/binary-cache.md, .github/workflows/build-and-push.yml, packages/options-doc)
- Switch claude-desktop package to claude-desktop-fhs
- Update devenv and pin git-hooks.nix to follow the repo's nixpkgs input, so hook tooling (e.g. flake-checker) stays in sync with nixpkgs bumps
- Document in README.org that a stale flake-checker complaining about the nixpkgs version can be fixed with `devenv update` + `devenv tasks run devenv:git-hooks:install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)