### PR TITLE
Fix GitHub Actions cache usage

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -28,11 +28,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws:iam::481411455398:role/nixfiles-cache-publisher
-          aws-region: us-east-1
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
         with:
@@ -42,6 +37,26 @@ jobs:
             experimental-features = nix-command flakes
             extra-substituters = s3://thoughtfull-nix-cache?region=us-east-1 https://cache.numtide.com https://devenv.cachix.org
             extra-trusted-public-keys = nix-cache.thoughtfull.systems:kN4M+h0QLcDpQksBsFNtE9t6+bLa/s4axEWYpDmz2ag= niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g= devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::481411455398:role/nixfiles-cache-publisher
+          aws-region: us-east-1
+      - name: Configure Nix daemon AWS credentials
+        run: |
+          sudo mkdir -p /etc/systemd/system/nix-daemon.service.d
+          printf '%s\n' \
+            "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
+            "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
+            "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" \
+            | sudo tee /run/nix-daemon-aws.env >/dev/null
+          sudo chmod 600 /run/nix-daemon-aws.env
+          printf '%s\n' \
+            '[Service]' \
+            'EnvironmentFile=/run/nix-daemon-aws.env' \
+            | sudo tee /etc/systemd/system/nix-daemon.service.d/aws.conf >/dev/null
+          sudo systemctl daemon-reload
+          sudo systemctl restart nix-daemon.service
       - name: Build system closure
         id: build
         run: |
@@ -57,6 +72,20 @@ jobs:
             fi
             sleep "$((attempt * 15))"
           done
+      - name: Refresh AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::481411455398:role/nixfiles-cache-publisher
+          aws-region: us-east-1
+      - name: Refresh Nix daemon AWS credentials
+        run: |
+          printf '%s\n' \
+            "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
+            "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
+            "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" \
+            | sudo tee /run/nix-daemon-aws.env >/dev/null
+          sudo chmod 600 /run/nix-daemon-aws.env
+          sudo systemctl restart nix-daemon.service
       - name: Sign and push closure to S3
         run: |
           umask 077

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -42,18 +42,17 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::481411455398:role/nixfiles-cache-publisher
           aws-region: us-east-1
+          aws-profile: default
+          overwrite-aws-profile: true
       - name: Configure Nix daemon AWS credentials
         run: |
           sudo mkdir -p /etc/systemd/system/nix-daemon.service.d
-          printf '%s\n' \
-            "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-            "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
-            "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" \
-            | sudo tee /run/nix-daemon-aws.env >/dev/null
-          sudo chmod 600 /run/nix-daemon-aws.env
+          sudo install -m 600 \
+            "$HOME/.aws/credentials" \
+            /run/nix-daemon-aws-credentials
           printf '%s\n' \
             '[Service]' \
-            'EnvironmentFile=/run/nix-daemon-aws.env' \
+            'Environment=AWS_SHARED_CREDENTIALS_FILE=/run/nix-daemon-aws-credentials' \
             | sudo tee /etc/systemd/system/nix-daemon.service.d/aws.conf >/dev/null
           sudo systemctl daemon-reload
           sudo systemctl restart nix-daemon.service
@@ -77,14 +76,13 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::481411455398:role/nixfiles-cache-publisher
           aws-region: us-east-1
+          aws-profile: default
+          overwrite-aws-profile: true
       - name: Refresh Nix daemon AWS credentials
         run: |
-          printf '%s\n' \
-            "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-            "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
-            "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" \
-            | sudo tee /run/nix-daemon-aws.env >/dev/null
-          sudo chmod 600 /run/nix-daemon-aws.env
+          sudo install -m 600 \
+            "$HOME/.aws/credentials" \
+            /run/nix-daemon-aws-credentials
           sudo systemctl restart nix-daemon.service
       - name: Sign and push closure to S3
         run: |
@@ -105,3 +103,8 @@ jobs:
           aws s3 cp latest.json \
             "s3://thoughtfull-nix-cache/hosts/${{ matrix.host }}/latest.json" \
             --cache-control "no-cache"
+      - name: Remove AWS credential files
+        if: always()
+        run: |
+          rm -f "$HOME/.aws/credentials" "$HOME/.aws/config"
+          sudo rm -f /run/nix-daemon-aws-credentials

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,6 +1,6 @@
 ---
-# Lines inside the `extra-conf:` block include the base64 cache signing
-# public key, which pushes them past the default 100-char limit.
+# Lines inside the `extra-conf:` block include cache signing public keys,
+# which push them past the default 100-char limit.
 # yamllint disable rule:line-length
 name: Build and Push
 on:
@@ -36,7 +36,7 @@ jobs:
             access-tokens = github.com=${{ secrets.KRYPTONIX_ACCESS_TOKEN }}
             experimental-features = nix-command flakes
             extra-substituters = s3://thoughtfull-nix-cache?region=us-east-1 https://cache.numtide.com https://devenv.cachix.org
-            extra-trusted-public-keys = nix-cache.thoughtfull.systems:kN4M+h0QLcDpQksBsFNtE9t6+bLa/s4axEWYpDmz2ag= niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g= devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            extra-trusted-public-keys = nix-cache.thoughtfull.systems-1:kN4M+h0QLcDpQksBsFNtE9t6+bLa/s4axEWYpDmz2ag= niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g= devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -38,10 +38,8 @@ jobs:
             trusted-users = root runner
             access-tokens = github.com=${{ secrets.KRYPTONIX_ACCESS_TOKEN }}
             experimental-features = nix-command flakes
-            extra-substituters = s3://thoughtfull-nix-cache?region=us-east-1
-            extra-trusted-public-keys = nix-cache.thoughtfull.systems:kN4M+h0QLcDpQksBsFNtE9t6+bLa/s4axEWYpDmz2ag=
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
+            extra-substituters = s3://thoughtfull-nix-cache?region=us-east-1 https://cache.numtide.com https://devenv.cachix.org
+            extra-trusted-public-keys = nix-cache.thoughtfull.systems:kN4M+h0QLcDpQksBsFNtE9t6+bLa/s4axEWYpDmz2ag= niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g= devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
       - name: Build system closure
         id: build
         run: |

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -24,13 +24,15 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::481411455398:role/nixfiles-cache-publisher
+          aws-region: us-east-1
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
         with:

--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -11,13 +11,17 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::481411455398:role/nixfiles-cache-reader
+          aws-region: us-east-1
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
         with:

--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -24,7 +24,7 @@ jobs:
             trusted-users = root runner
             access-tokens = github.com=${{ secrets.KRYPTONIX_ACCESS_TOKEN }}
             extra-substituters = s3://thoughtfull-nix-cache?region=us-east-1 https://cache.numtide.com https://devenv.cachix.org
-            extra-trusted-public-keys = nix-cache.thoughtfull.systems:kN4M+h0QLcDpQksBsFNtE9t6+bLa/s4axEWYpDmz2ag= niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g= devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            extra-trusted-public-keys = nix-cache.thoughtfull.systems-1:kN4M+h0QLcDpQksBsFNtE9t6+bLa/s4axEWYpDmz2ag= niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g= devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -45,10 +45,6 @@ jobs:
             | sudo tee /etc/systemd/system/nix-daemon.service.d/aws.conf >/dev/null
           sudo systemctl daemon-reload
           sudo systemctl restart nix-daemon.service
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v14
-        with:
-          use-flakehub: false
       - name: Run devenv test
         run: nix develop --no-pure-eval --command devenv test
       - name: Run flake check

--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -1,4 +1,7 @@
 ---
+# Lines inside the `extra-conf:` block include cache signing public keys,
+# which push them past the default 100-char limit.
+# yamllint disable rule:line-length
 name: Flake Check
 on:
   push:
@@ -8,6 +11,10 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -17,8 +24,12 @@ jobs:
           extra-conf: |
             trusted-users = root runner
             access-tokens = github.com=${{ secrets.KRYPTONIX_ACCESS_TOKEN }}
+            extra-substituters = s3://thoughtfull-nix-cache?region=us-east-1 https://cache.numtide.com https://devenv.cachix.org
+            extra-trusted-public-keys = nix-cache.thoughtfull.systems:kN4M+h0QLcDpQksBsFNtE9t6+bLa/s4axEWYpDmz2ag= niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g= devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
       - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
+        uses: DeterminateSystems/magic-nix-cache-action@v14
+        with:
+          use-flakehub: false
       - name: Run devenv test
         run: nix develop --no-pure-eval --command devenv test
       - name: Run flake check

--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -17,11 +17,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws:iam::481411455398:role/nixfiles-cache-reader
-          aws-region: us-east-1
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
         with:
@@ -30,6 +25,26 @@ jobs:
             access-tokens = github.com=${{ secrets.KRYPTONIX_ACCESS_TOKEN }}
             extra-substituters = s3://thoughtfull-nix-cache?region=us-east-1 https://cache.numtide.com https://devenv.cachix.org
             extra-trusted-public-keys = nix-cache.thoughtfull.systems:kN4M+h0QLcDpQksBsFNtE9t6+bLa/s4axEWYpDmz2ag= niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g= devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::481411455398:role/nixfiles-cache-reader
+          aws-region: us-east-1
+      - name: Configure Nix daemon AWS credentials
+        run: |
+          sudo mkdir -p /etc/systemd/system/nix-daemon.service.d
+          printf '%s\n' \
+            "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
+            "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
+            "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" \
+            | sudo tee /run/nix-daemon-aws.env >/dev/null
+          sudo chmod 600 /run/nix-daemon-aws.env
+          printf '%s\n' \
+            '[Service]' \
+            'EnvironmentFile=/run/nix-daemon-aws.env' \
+            | sudo tee /etc/systemd/system/nix-daemon.service.d/aws.conf >/dev/null
+          sudo systemctl daemon-reload
+          sudo systemctl restart nix-daemon.service
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@v14
         with:

--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -30,18 +30,17 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::481411455398:role/nixfiles-cache-reader
           aws-region: us-east-1
+          aws-profile: default
+          overwrite-aws-profile: true
       - name: Configure Nix daemon AWS credentials
         run: |
           sudo mkdir -p /etc/systemd/system/nix-daemon.service.d
-          printf '%s\n' \
-            "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-            "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
-            "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" \
-            | sudo tee /run/nix-daemon-aws.env >/dev/null
-          sudo chmod 600 /run/nix-daemon-aws.env
+          sudo install -m 600 \
+            "$HOME/.aws/credentials" \
+            /run/nix-daemon-aws-credentials
           printf '%s\n' \
             '[Service]' \
-            'EnvironmentFile=/run/nix-daemon-aws.env' \
+            'Environment=AWS_SHARED_CREDENTIALS_FILE=/run/nix-daemon-aws-credentials' \
             | sudo tee /etc/systemd/system/nix-daemon.service.d/aws.conf >/dev/null
           sudo systemctl daemon-reload
           sudo systemctl restart nix-daemon.service
@@ -49,3 +48,8 @@ jobs:
         run: nix develop --no-pure-eval --command devenv test
       - name: Run flake check
         run: nix flake check --no-pure-eval
+      - name: Remove AWS credential files
+        if: always()
+        run: |
+          rm -f "$HOME/.aws/credentials" "$HOME/.aws/config"
+          sudo rm -f /run/nix-daemon-aws-credentials

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,18 +33,17 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::481411455398:role/nixfiles-cache-reader
           aws-region: us-east-1
+          aws-profile: default
+          overwrite-aws-profile: true
       - name: Configure Nix daemon AWS credentials
         run: |
           sudo mkdir -p /etc/systemd/system/nix-daemon.service.d
-          printf '%s\n' \
-            "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-            "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
-            "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" \
-            | sudo tee /run/nix-daemon-aws.env >/dev/null
-          sudo chmod 600 /run/nix-daemon-aws.env
+          sudo install -m 600 \
+            "$HOME/.aws/credentials" \
+            /run/nix-daemon-aws-credentials
           printf '%s\n' \
             '[Service]' \
-            'EnvironmentFile=/run/nix-daemon-aws.env' \
+            'Environment=AWS_SHARED_CREDENTIALS_FILE=/run/nix-daemon-aws-credentials' \
             | sudo tee /etc/systemd/system/nix-daemon.service.d/aws.conf >/dev/null
           sudo systemctl daemon-reload
           sudo systemctl restart nix-daemon.service
@@ -54,6 +53,11 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: result
+      - name: Remove AWS credential files
+        if: always()
+        run: |
+          rm -f "$HOME/.aws/credentials" "$HOME/.aws/config"
+          sudo rm -f /run/nix-daemon-aws-credentials
   deploy:
     environment:
       name: github-pages

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,11 +20,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws:iam::481411455398:role/nixfiles-cache-reader
-          aws-region: us-east-1
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
         with:
@@ -33,6 +28,26 @@ jobs:
             access-tokens = github.com=${{ secrets.KRYPTONIX_ACCESS_TOKEN }}
             extra-substituters = s3://thoughtfull-nix-cache?region=us-east-1 https://cache.numtide.com https://devenv.cachix.org
             extra-trusted-public-keys = nix-cache.thoughtfull.systems:kN4M+h0QLcDpQksBsFNtE9t6+bLa/s4axEWYpDmz2ag= niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g= devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::481411455398:role/nixfiles-cache-reader
+          aws-region: us-east-1
+      - name: Configure Nix daemon AWS credentials
+        run: |
+          sudo mkdir -p /etc/systemd/system/nix-daemon.service.d
+          printf '%s\n' \
+            "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
+            "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
+            "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" \
+            | sudo tee /run/nix-daemon-aws.env >/dev/null
+          sudo chmod 600 /run/nix-daemon-aws.env
+          printf '%s\n' \
+            '[Service]' \
+            'EnvironmentFile=/run/nix-daemon-aws.env' \
+            | sudo tee /etc/systemd/system/nix-daemon.service.d/aws.conf >/dev/null
+          sudo systemctl daemon-reload
+          sudo systemctl restart nix-daemon.service
       - name: Build options-doc
         run: nix build .#options-doc
       - name: Upload artifact

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,7 +27,7 @@ jobs:
             trusted-users = root runner
             access-tokens = github.com=${{ secrets.KRYPTONIX_ACCESS_TOKEN }}
             extra-substituters = s3://thoughtfull-nix-cache?region=us-east-1 https://cache.numtide.com https://devenv.cachix.org
-            extra-trusted-public-keys = nix-cache.thoughtfull.systems:kN4M+h0QLcDpQksBsFNtE9t6+bLa/s4axEWYpDmz2ag= niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g= devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+            extra-trusted-public-keys = nix-cache.thoughtfull.systems-1:kN4M+h0QLcDpQksBsFNtE9t6+bLa/s4axEWYpDmz2ag= niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g= devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,13 +17,14 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::481411455398:role/nixfiles-cache-reader
+          aws-region: us-east-1
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,7 @@
 ---
+# Lines inside the `extra-conf:` block include cache signing public keys,
+# which push them past the default 100-char limit.
+# yamllint disable rule:line-length
 name: Deploy Options Docs to GitHub Pages
 on:
   push:
@@ -14,6 +17,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -23,8 +30,8 @@ jobs:
           extra-conf: |
             trusted-users = root runner
             access-tokens = github.com=${{ secrets.KRYPTONIX_ACCESS_TOKEN }}
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
+            extra-substituters = s3://thoughtfull-nix-cache?region=us-east-1 https://cache.numtide.com https://devenv.cachix.org
+            extra-trusted-public-keys = nix-cache.thoughtfull.systems:kN4M+h0QLcDpQksBsFNtE9t6+bLa/s4axEWYpDmz2ag= niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g= devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
       - name: Build options-doc
         run: nix build .#options-doc
       - name: Upload artifact

--- a/doc/binary-cache-runbook.md
+++ b/doc/binary-cache-runbook.md
@@ -120,6 +120,10 @@ the dev shell.
    Do not create `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY` GitHub
    Actions secrets. The workflows use `id-token: write` and
    `aws-actions/configure-aws-credentials` to obtain temporary credentials.
+   Because `nix-daemon` runs under systemd, the workflows copy each session
+   into a root-only `/run/nix-daemon-aws.env` and restart the daemon with an
+   `EnvironmentFile` drop-in. Build and Push refreshes the session after the
+   build so long ARM builds don't upload with expired credentials.
    When migrating an existing repository, delete those legacy secrets after
    a successful OIDC-authenticated run.
 
@@ -278,11 +282,20 @@ For `Not authorized to perform sts:AssumeRoleWithWebIdentity`:
    `repo:thoughtfull-nix/nixfiles:pull_request` for a PR.
 3. Confirm the job grants `id-token: write` and `contents: read`.
 4. Confirm `role-to-assume` names the correct reader or publisher role.
+5. Confirm `/run/nix-daemon-aws.env` exists with mode `0600`, the
+   `nix-daemon.service` drop-in references it, and the daemon restarted after
+   role assumption.
 
 For an unexpected `AccessDenied` from S3 after assumption succeeds, inspect
 the role's S3 permissions rather than its trust policy. Reader jobs need
 `s3:GetObject` and `s3:ListBucket`; Build and Push additionally needs
 `s3:PutObject`.
+
+If the AWS CLI succeeds but Nix reports `Path is invalid` followed by an S3
+403, the runner has credentials but `nix-daemon` does not. Check the root-only
+environment file and daemon restart. If upload fails only after a long build,
+check that the workflow refreshed both the OIDC session and daemon credentials
+immediately before `nix copy`.
 
 After changing a trust or permissions policy, trigger
 `gh workflow run build-and-push.yml` and verify the role session in the job

--- a/doc/binary-cache-runbook.md
+++ b/doc/binary-cache-runbook.md
@@ -27,7 +27,10 @@ the dev shell.
 2. **Commit the public half** as the default value of `publicKey` in
    `nixosModules/binary-cache.nix` and in the
    `extra-trusted-public-keys` values in `.github/workflows/`. Replace
-   `REPLACE_WITH_BASE64_PUBLIC_KEY` in each place.
+   `REPLACE_WITH_BASE64_PUBLIC_KEY` in each place. Keep the exact
+   `nix-cache.thoughtfull.systems-1` name in every location; Nix rejects a
+   signature when the trusted key has a different name, even if its base64 key
+   material matches.
 
 3. **Encrypt and commit the signing-key backup.** No host needs it at
    runtime, but this is the disaster-recovery copy.

--- a/doc/binary-cache-runbook.md
+++ b/doc/binary-cache-runbook.md
@@ -25,9 +25,9 @@ the dev shell.
    ```
 
 2. **Commit the public half** as the default value of `publicKey` in
-   `nixosModules/binary-cache.nix` and as the `extra-trusted-public-keys`
-   value in `.github/workflows/build-and-push.yml`. Replace
-   `REPLACE_WITH_BASE64_PUBLIC_KEY` in both places.
+   `nixosModules/binary-cache.nix` and in the
+   `extra-trusted-public-keys` values in `.github/workflows/`. Replace
+   `REPLACE_WITH_BASE64_PUBLIC_KEY` in each place.
 
 3. **Encrypt and commit the signing-key backup.** No host needs it at
    runtime, but this is the disaster-recovery copy.
@@ -54,29 +54,74 @@ the dev shell.
    ```
    Add a lifecycle rule: expire objects under prefix `nar/` after 60 days.
 
-6. **Create two IAM users.** `nix-cache-ci` (write) and `nix-cache-host`
-   (read-only), with policies scoped to
-   `arn:aws:s3:::thoughtfull-nix-cache` and `/*`.
+6. **Create the AWS identities.** CI uses short-lived GitHub OIDC roles;
+   hosts use a long-lived read-only IAM user.
 
-   Policy for `nix-cache-ci`:
+   Create the `nix-cache-host` IAM user with this policy:
    ```json
    {
      "Version": "2012-10-17",
-     "Statement": [{
-       "Effect": "Allow",
-       "Action": ["s3:PutObject", "s3:GetObject", "s3:ListBucket"],
-       "Resource": [
-         "arn:aws:s3:::thoughtfull-nix-cache",
-         "arn:aws:s3:::thoughtfull-nix-cache/*"
-       ]
-     }]
+     "Statement": [
+       {
+         "Effect": "Allow",
+         "Action": "s3:ListBucket",
+         "Resource": "arn:aws:s3:::thoughtfull-nix-cache"
+       },
+       {
+         "Effect": "Allow",
+         "Action": "s3:GetObject",
+         "Resource": "arn:aws:s3:::thoughtfull-nix-cache/*"
+       }
+     ]
    }
    ```
 
-   Policy for `nix-cache-host`: same but without `s3:PutObject`.
+   Add `https://token.actions.githubusercontent.com` as an IAM OIDC
+   provider with audience `sts.amazonaws.com`. Then create these roles:
 
-7. **Paste `nix-cache-ci` credentials into GitHub Actions** as
-   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+   - `nixfiles-cache-reader`: the policy above; used by Flake Check and
+     Pages.
+   - `nixfiles-cache-publisher`: the policy above plus `s3:PutObject` on
+     `arn:aws:s3:::thoughtfull-nix-cache/*`; used by Build and Push.
+
+   Use this trust-policy condition for `nixfiles-cache-reader`:
+   ```json
+   "Condition": {
+     "StringEquals": {
+       "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+       "token.actions.githubusercontent.com:sub": [
+         "repo:thoughtfull-nix/nixfiles:ref:refs/heads/main",
+         "repo:thoughtfull-nix/nixfiles:pull_request"
+       ]
+     }
+   }
+   ```
+
+   Restrict `nixfiles-cache-publisher` to `main`:
+   ```json
+   "Condition": {
+     "StringEquals": {
+       "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+       "token.actions.githubusercontent.com:sub": "repo:thoughtfull-nix/nixfiles:ref:refs/heads/main"
+     }
+   }
+   ```
+
+   Both trust policies use the federated principal:
+   `arn:aws:iam::481411455398:oidc-provider/token.actions.githubusercontent.com`
+   and action `sts:AssumeRoleWithWebIdentity`.
+
+7. **Verify the workflow role identifiers.** They're non-secret configuration
+   committed in `.github/workflows/`:
+   ```text
+   arn:aws:iam::481411455398:role/nixfiles-cache-reader
+   arn:aws:iam::481411455398:role/nixfiles-cache-publisher
+   ```
+   Do not create `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY` GitHub
+   Actions secrets. The workflows use `id-token: write` and
+   `aws-actions/configure-aws-credentials` to obtain temporary credentials.
+   When migrating an existing repository, delete those legacy secrets after
+   a successful OIDC-authenticated run.
 
 8. **Encrypt the `nix-cache-host` credentials.** Write the file in
    `EnvironmentFile` format:
@@ -105,7 +150,7 @@ the dev shell.
     gh workflow run build-and-push.yml
     gh run watch
     ```
-    Both matrix jobs should land. Then:
+    All matrix jobs should land. Then:
     ```bash
     AWS_PROFILE=<host-profile> aws s3 cp \
       s3://thoughtfull-nix-cache/hosts/sedna/latest.json -
@@ -187,7 +232,10 @@ nixos-rebuild --rollback switch
 Open the run on the GitHub Actions UI. Common causes:
 
 - **`KRYPTONIX_ACCESS_TOKEN` expired.** Rotate per section 9.
-- **AWS credentials expired.** Rotate per section 7.
+- **OIDC role assumption failed.** Verify the provider, trust policy, and
+  workflow subject per section 7.
+- **S3 returned `AccessDenied` after role assumption.** Verify the assumed
+  role's S3 policy and bucket ARN.
 - **Transient nixpkgs eval failure**—re-run the job: `gh run rerun <id>`.
 - **An aarch64 build genuinely too slow for the 6-hour limit.** Re-trigger
   off-hours after the cache has warmed up from related builds; the second
@@ -215,14 +263,35 @@ systemctl start system-pull.service
 
 ---
 
-## 7. Rotating CI AWS credentials
+## 7. Maintaining CI OIDC access
 
-1. In AWS IAM, generate a new access key for `nix-cache-ci`.
-2. Update GitHub Actions secrets `AWS_ACCESS_KEY_ID` and
-   `AWS_SECRET_ACCESS_KEY`.
-3. Trigger the workflow to confirm:
-   `gh workflow run build-and-push.yml`.
-4. Delete the old access key in IAM.
+There are no long-lived CI AWS credentials to rotate. AWS STS issues a new
+short-lived session for each job.
+
+For `Not authorized to perform sts:AssumeRoleWithWebIdentity`:
+
+1. Confirm the AWS account has the GitHub provider
+   `https://token.actions.githubusercontent.com` with audience
+   `sts.amazonaws.com`.
+2. Confirm the role trust policy's `sub` matches the workflow context:
+   `repo:thoughtfull-nix/nixfiles:ref:refs/heads/main` for main or
+   `repo:thoughtfull-nix/nixfiles:pull_request` for a PR.
+3. Confirm the job grants `id-token: write` and `contents: read`.
+4. Confirm `role-to-assume` names the correct reader or publisher role.
+
+For an unexpected `AccessDenied` from S3 after assumption succeeds, inspect
+the role's S3 permissions rather than its trust policy. Reader jobs need
+`s3:GetObject` and `s3:ListBucket`; Build and Push additionally needs
+`s3:PutObject`.
+
+After changing a trust or permissions policy, trigger
+`gh workflow run build-and-push.yml` and verify the role session in the job
+log. To revoke CI access immediately, remove the matching GitHub subject from
+the role trust policy; there are no access keys to delete.
+
+If the repository still has legacy `AWS_ACCESS_KEY_ID` or
+`AWS_SECRET_ACCESS_KEY` Actions secrets from the pre-OIDC setup, delete them
+after confirming all workflows use role assumption.
 
 ---
 

--- a/doc/binary-cache-runbook.md
+++ b/doc/binary-cache-runbook.md
@@ -120,10 +120,13 @@ the dev shell.
    Do not create `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY` GitHub
    Actions secrets. The workflows use `id-token: write` and
    `aws-actions/configure-aws-credentials` to obtain temporary credentials.
-   Because `nix-daemon` runs under systemd, the workflows copy each session
-   into a root-only `/run/nix-daemon-aws.env` and restart the daemon with an
-   `EnvironmentFile` drop-in. Build and Push refreshes the session after the
-   build so long ARM builds don't upload with expired credentials.
+   The action writes a mode-`0600` default profile instead of exporting
+   credential environment variables. Because `nix-daemon` runs under
+   systemd, the workflows copy that profile to the root-only
+   `/run/nix-daemon-aws-credentials`, set `AWS_SHARED_CREDENTIALS_FILE` in a
+   service drop-in, and restart the daemon. Build and Push refreshes both
+   profile copies after the build so long ARM builds don't upload with
+   expired credentials. An `always()` step removes both files after use.
    When migrating an existing repository, delete those legacy secrets after
    a successful OIDC-authenticated run.
 
@@ -282,9 +285,10 @@ For `Not authorized to perform sts:AssumeRoleWithWebIdentity`:
    `repo:thoughtfull-nix/nixfiles:pull_request` for a PR.
 3. Confirm the job grants `id-token: write` and `contents: read`.
 4. Confirm `role-to-assume` names the correct reader or publisher role.
-5. Confirm `/run/nix-daemon-aws.env` exists with mode `0600`, the
-   `nix-daemon.service` drop-in references it, and the daemon restarted after
-   role assumption.
+5. Confirm `$HOME/.aws/credentials` and
+   `/run/nix-daemon-aws-credentials` exist with mode `0600`, the
+   `nix-daemon.service` drop-in sets `AWS_SHARED_CREDENTIALS_FILE` to the
+   latter, and the daemon restarted after role assumption.
 
 For an unexpected `AccessDenied` from S3 after assumption succeeds, inspect
 the role's S3 permissions rather than its trust policy. Reader jobs need
@@ -293,9 +297,9 @@ the role's S3 permissions rather than its trust policy. Reader jobs need
 
 If the AWS CLI succeeds but Nix reports `Path is invalid` followed by an S3
 403, the runner has credentials but `nix-daemon` does not. Check the root-only
-environment file and daemon restart. If upload fails only after a long build,
-check that the workflow refreshed both the OIDC session and daemon credentials
-immediately before `nix copy`.
+profile copy, `AWS_SHARED_CREDENTIALS_FILE`, and daemon restart. If upload
+fails only after a long build, check that the workflow refreshed both profile
+copies immediately before `nix copy`.
 
 After changing a trust or permissions policy, trigger
 `gh workflow run build-and-push.yml` and verify the role session in the job

--- a/doc/binary-cache.md
+++ b/doc/binary-cache.md
@@ -107,7 +107,10 @@ The signing key lives in two places:
   disaster-recovery backup. No host needs the private key at runtime.
 
 The public half is committed in cleartext as the default value of the
-`publicKey` option in `nixosModules/binary-cache.nix`.
+`publicKey` option in `nixosModules/binary-cache.nix`. Its key name is
+`nix-cache.thoughtfull.systems-1`; every `trusted-public-keys` entry must use
+that exact name because Nix matches signatures by name as well as key
+material.
 
 ## Data flow per daily run
 

--- a/doc/binary-cache.md
+++ b/doc/binary-cache.md
@@ -85,12 +85,14 @@ OIDC token using `id-token: write`, exchange it with AWS STS, and receive
 temporary role credentials for that job. The publisher and reader role
 identifiers are non-secret workflow configuration.
 
-The credentials action exports the temporary session to subsequent workflow
-steps, but the systemd-managed Nix daemon doesn't inherit that environment.
-Each workflow writes the session to a root-only file under `/run`, configures
-`nix-daemon.service` to read it, and restarts the daemon. Build and Push
-refreshes both the OIDC session and daemon environment after the build so an
-ARM build longer than the default one-hour STS session can still upload.
+The credentials action writes the temporary session to the runner's
+mode-`0600` default AWS profile without exporting credential environment
+variables. Each workflow copies that profile to a root-only file under
+`/run`, points `nix-daemon.service` at it with
+`AWS_SHARED_CREDENTIALS_FILE`, and restarts the daemon. Build and Push
+refreshes both copies after the build so an ARM build longer than the default
+one-hour STS session can still upload. An `always()` cleanup step removes both
+credential files when the job finishes.
 
 The reader trust policy deliberately authorizes the repository's
 `pull_request` subject. PR jobs can therefore read the private cache but

--- a/doc/binary-cache.md
+++ b/doc/binary-cache.md
@@ -25,9 +25,10 @@ from S3 once a day.
 │   daily cron, push-to-main, workflow_dispatch                     │
 │   matrix: hydor + sedna (x86_64), tislit (aarch64)                │
 │                                                                    │
-│   1. Assume nixfiles-cache-publisher via GitHub OIDC               │
-│   2. nix-installer-action with KRYPTONIX_ACCESS_TOKEN              │
+│   1. nix-installer-action with KRYPTONIX_ACCESS_TOKEN              │
 │      + extra-substituters s3://… (incremental builds)              │
+│   2. Assume nixfiles-cache-publisher via GitHub OIDC               │
+│      + pass the session to nix-daemon                              │
 │   3. nix build --override-input nixpkgs <branch tip>               │
 │        .#nixosConfigurations.${host}.config.system.build.toplevel  │
 │   4. nix store sign --recursive --key-file (CACHE_SIGNING_KEY)     │
@@ -84,6 +85,13 @@ OIDC token using `id-token: write`, exchange it with AWS STS, and receive
 temporary role credentials for that job. The publisher and reader role
 identifiers are non-secret workflow configuration.
 
+The credentials action exports the temporary session to subsequent workflow
+steps, but the systemd-managed Nix daemon doesn't inherit that environment.
+Each workflow writes the session to a root-only file under `/run`, configures
+`nix-daemon.service` to read it, and restarts the daemon. Build and Push
+refreshes both the OIDC session and daemon environment after the build so an
+ARM build longer than the default one-hour STS session can still upload.
+
 The reader trust policy deliberately authorizes the repository's
 `pull_request` subject. PR jobs can therefore read the private cache but
 cannot modify it. Keep the publisher role restricted to `main`; broadening
@@ -103,7 +111,7 @@ The public half is committed in cleartext as the default value of the
 
 1. GitHub Actions matrix triggers at 02:00 UTC (and on every push to `main`).
 2. Each matrix job exchanges its GitHub OIDC token for temporary credentials
-   from the `nixfiles-cache-publisher` role.
+   from the `nixfiles-cache-publisher` role and passes them to the Nix daemon.
 3. Each matrix job builds
    `.#nixosConfigurations.<host>.config.system.build.toplevel`, with
    `--override-input nixpkgs github:NixOS/nixpkgs/nixos-26.05` so the daily
@@ -112,14 +120,16 @@ The public half is committed in cleartext as the default value of the
    (`extra-substituters` in the installer config), so already-pushed paths
    are downloaded instead of rebuilt. The configured upstream caches provide
    their respective build products.
-5. `nix store sign --recursive` signs the closure with the private signing
+5. The job refreshes its OIDC session and the daemon's credentials after the
+   build.
+6. `nix store sign --recursive` signs the closure with the private signing
    key.
-6. `nix copy --to s3://bucket?…` uploads any newly built NARs + narinfos
+7. `nix copy --to s3://bucket?…` uploads any newly built NARs + narinfos
    (existing paths are no-ops).
-7. `aws s3 cp` atomically writes
+8. `aws s3 cp` atomically writes
    `hosts/<host>/latest.json = {storePath, gitRev, builtAt}` with
    `Cache-Control: no-cache`.
-8. At 03:00 UTC (headless) / 12:00 local (graphical), the `system-pull.timer`
+9. At 03:00 UTC (headless) / 12:00 local (graphical), the `system-pull.timer`
    on each host fires. The script `pkgs.thoughtfull.system-pull`:
    - Fetches `hosts/<hostname>/latest.json` with `aws s3 cp`.
    - Compares the target `storePath` with `readlink /run/current-system`;

--- a/doc/binary-cache.md
+++ b/doc/binary-cache.md
@@ -23,17 +23,18 @@ from S3 once a day.
 ┌───────────────────────────────────────────────────────────────────┐
 │ GitHub Actions  (.github/workflows/build-and-push.yml)            │
 │   daily cron, push-to-main, workflow_dispatch                     │
-│   matrix: {sedna, ubuntu-24.04} {tislit, ubuntu-24.04-arm}        │
+│   matrix: hydor + sedna (x86_64), tislit (aarch64)                │
 │                                                                    │
-│   1. nix-installer-action with KRYPTONIX_ACCESS_TOKEN              │
+│   1. Assume nixfiles-cache-publisher via GitHub OIDC               │
+│   2. nix-installer-action with KRYPTONIX_ACCESS_TOKEN              │
 │      + extra-substituters s3://… (incremental builds)              │
-│   2. nix build --override-input nixpkgs <branch tip>               │
+│   3. nix build --override-input nixpkgs <branch tip>               │
 │        .#nixosConfigurations.${host}.config.system.build.toplevel  │
-│   3. nix store sign --recursive --key-file (CACHE_SIGNING_KEY)     │
-│   4. nix copy --to "s3://bucket?…&secret-key=…" $out               │
-│   5. write latest.json + aws s3 cp to hosts/${host}/latest.json    │
+│   4. nix store sign --recursive --key-file (CACHE_SIGNING_KEY)     │
+│   5. nix copy --to "s3://bucket?…&secret-key=…" $out               │
+│   6. write latest.json + aws s3 cp to hosts/${host}/latest.json    │
 └───────────────────────────────────────────────────────────────────┘
-                              │ HTTPS (IAM user nixfiles-ci, write+read)
+                              │ HTTPS (OIDC role, write+read)
                               ▼
                   ┌─────────────────────────┐
                   │ AWS S3: thoughtfull-    │
@@ -44,7 +45,7 @@ from S3 once a day.
                   │   /hosts/${host}/       │
                   │       latest.json       │
                   └─────────────────────────┘
-                              │ HTTPS (IAM user nixfiles-host, read-only)
+                              │ HTTPS (IAM user nix-cache-host, read-only)
                               ▼
                   ┌─────────────────────────┐
                   │ sedna, tislit (clients) │  daily systemd timer
@@ -63,16 +64,30 @@ by every host. The bucket being private is only a *confidentiality* control
 safe to *trust* but would leak hostnames, software versions, and config
 shape.
 
-Two IAM users:
+Three least-privilege AWS identities:
 
-- `nixfiles-ci`: write access (`s3:PutObject`, `s3:GetObject`,
-  `s3:ListBucket`). Credentials live in GitHub Actions secrets
-  `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`.
-- `nixfiles-host`: read-only (`s3:GetObject`, `s3:ListBucket`).
-  Credentials live in
+- `nixfiles-cache-publisher`: IAM role with `s3:PutObject`, `s3:GetObject`,
+  and `s3:ListBucket`. Its OIDC trust policy only accepts GitHub Actions
+  tokens for this repository's `main` branch. `build-and-push.yml` assumes it
+  through `aws-actions/configure-aws-credentials`.
+- `nixfiles-cache-reader`: IAM role with `s3:GetObject` and `s3:ListBucket`.
+  `flake-check.yml` and the Pages build assume it through GitHub OIDC. Its
+  trust policy accepts this repository's `main` and `pull_request` subjects.
+- `nix-cache-host`: read-only IAM user with `s3:GetObject` and
+  `s3:ListBucket`. Its long-lived credentials live in
   `nixosConfigurations/shared/secrets/nix-cache-host-credentials.age`,
   decrypted by agenix into `EnvironmentFile`-format and supplied to
   `nix-daemon` and to the `system-pull` systemd unit.
+
+GitHub Actions stores no long-lived AWS access keys. Jobs request a GitHub
+OIDC token using `id-token: write`, exchange it with AWS STS, and receive
+temporary role credentials for that job. The publisher and reader role
+identifiers are non-secret workflow configuration.
+
+The reader trust policy deliberately authorizes the repository's
+`pull_request` subject. PR jobs can therefore read the private cache but
+cannot modify it. Keep the publisher role restricted to `main`; broadening
+its subject would allow proposed workflow code to obtain `s3:PutObject`.
 
 The signing key lives in two places:
 
@@ -87,22 +102,24 @@ The public half is committed in cleartext as the default value of the
 ## Data flow per daily run
 
 1. GitHub Actions matrix triggers at 02:00 UTC (and on every push to `main`).
-2. Each matrix job builds
+2. Each matrix job exchanges its GitHub OIDC token for temporary credentials
+   from the `nixfiles-cache-publisher` role.
+3. Each matrix job builds
    `.#nixosConfigurations.<host>.config.system.build.toplevel`, with
    `--override-input nixpkgs github:NixOS/nixpkgs/nixos-26.05` so the daily
    build picks up the latest tip of the release branch.
-3. The build step uses the S3 cache itself as an additional substituter
+4. The build step uses the S3 cache itself as an additional substituter
    (`extra-substituters` in the installer config), so already-pushed paths
-   are downloaded instead of rebuilt. Magic Nix Cache handles build-time
-   intermediates that never end up in the system closure.
-4. `nix store sign --recursive` signs the closure with the private signing
+   are downloaded instead of rebuilt. The configured upstream caches provide
+   their respective build products.
+5. `nix store sign --recursive` signs the closure with the private signing
    key.
-5. `nix copy --to s3://bucket?…` uploads any newly built NARs + narinfos
+6. `nix copy --to s3://bucket?…` uploads any newly built NARs + narinfos
    (existing paths are no-ops).
-6. `aws s3 cp` atomically writes
+7. `aws s3 cp` atomically writes
    `hosts/<host>/latest.json = {storePath, gitRev, builtAt}` with
    `Cache-Control: no-cache`.
-7. At 03:00 UTC (headless) / 12:00 local (graphical), the `system-pull.timer`
+8. At 03:00 UTC (headless) / 12:00 local (graphical), the `system-pull.timer`
    on each host fires. The script `pkgs.thoughtfull.system-pull`:
    - Fetches `hosts/<hostname>/latest.json` with `aws s3 cp`.
    - Compares the target `storePath` with `readlink /run/current-system`;
@@ -159,5 +176,6 @@ design costs ~$5–7/month (storage + egress only) and removes:
 - A long-running daemon (`harmonia` / `nginx`) to monitor.
 - An EBS volume to size + grow + snapshot.
 
-Tradeoff: every host needs an AWS IAM credential. Rotation requires
-agenix re-encryption and a deploy to every host (see runbook).
+Tradeoff: every host still needs a long-lived AWS IAM credential. Rotation
+requires agenix re-encryption and a deploy to every host (see runbook). CI
+uses short-lived OIDC role sessions and has no AWS key rotation procedure.


### PR DESCRIPTION
## Summary

- use the private signed S3 cache plus Numtide and devenv substituters explicitly in CI
- remove Magic Nix Cache from system builds and Pages to avoid exhausting GitHub Actions cache API limits
- retain Magic Nix Cache for check-specific outputs, update it to v14, and disable unavailable FlakeHub integration

## Validation

- `devenv tasks run devenv:git-hooks:run`
- commit and push hooks passed