### PR TITLE
Add remote-provision and finish-remote-provision subcommands

### DIFF
--- a/.config/yamlfmt.yaml
+++ b/.config/yamlfmt.yaml
@@ -3,3 +3,4 @@ formatter:
   type: basic
   include_document_start: true
   max_line_length: 100
+  scan_folded_as_literal: true

--- a/.github/actions/cleanup-nix-daemon-aws-creds/action.yml
+++ b/.github/actions/cleanup-nix-daemon-aws-creds/action.yml
@@ -1,0 +1,14 @@
+---
+name: Remove AWS credential files
+description: >
+  Deletes the runner- and nix-daemon-side credential files written by the
+  `configure-nix-daemon-aws-creds` action. Run this as a final `if: always()` step in any job that
+  used it.
+runs:
+  using: composite
+  steps:
+    - name: Remove AWS credential files
+      shell: bash
+      run: |
+        rm -f "$HOME/.aws/credentials" "$HOME/.aws/config"
+        sudo rm -f /run/nix-daemon-aws-credentials

--- a/.github/actions/configure-nix-daemon-aws-creds/action.yml
+++ b/.github/actions/configure-nix-daemon-aws-creds/action.yml
@@ -1,0 +1,37 @@
+---
+name: Configure Nix daemon AWS credentials
+description: >
+  Assumes an AWS IAM role via GitHub OIDC and wires the resulting temporary credentials into the
+  system nix-daemon, so S3 substituters/`nix copy` authenticate as that role. Requires the caller's
+  job to set `permissions: id-token: write`. Pair with the `cleanup-nix-daemon-aws-creds` action in
+  an `if: always()` step.
+inputs:
+  role-to-assume:
+    description: ARN of the IAM role to assume via GitHub OIDC.
+    required: true
+  aws-region:
+    description: AWS region to assume the role in.
+    default: us-east-1
+runs:
+  using: composite
+  steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: ${{ inputs.role-to-assume }}
+        aws-region: ${{ inputs.aws-region }}
+        aws-profile: default
+        overwrite-aws-profile: true
+    - name: Configure Nix daemon AWS credentials
+      shell: bash
+      run: |
+        sudo mkdir -p /etc/systemd/system/nix-daemon.service.d
+        sudo install -m 600 \
+          "$HOME/.aws/credentials" \
+          /run/nix-daemon-aws-credentials
+        printf '%s\n' \
+          '[Service]' \
+          'Environment=AWS_SHARED_CREDENTIALS_FILE=/run/nix-daemon-aws-credentials' \
+          | sudo tee /etc/systemd/system/nix-daemon.service.d/aws.conf >/dev/null
+        sudo systemctl daemon-reload
+        sudo systemctl restart nix-daemon.service

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -37,25 +37,10 @@ jobs:
             experimental-features = nix-command flakes
             extra-substituters = s3://thoughtfull-nix-cache?region=us-east-1 https://cache.numtide.com https://devenv.cachix.org
             extra-trusted-public-keys = nix-cache.thoughtfull.systems-1:kN4M+h0QLcDpQksBsFNtE9t6+bLa/s4axEWYpDmz2ag= niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g= devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+      - name: Configure Nix daemon AWS credentials
+        uses: ./.github/actions/configure-nix-daemon-aws-creds
         with:
           role-to-assume: arn:aws:iam::481411455398:role/nixfiles-cache-publisher
-          aws-region: us-east-1
-          aws-profile: default
-          overwrite-aws-profile: true
-      - name: Configure Nix daemon AWS credentials
-        run: |
-          sudo mkdir -p /etc/systemd/system/nix-daemon.service.d
-          sudo install -m 600 \
-            "$HOME/.aws/credentials" \
-            /run/nix-daemon-aws-credentials
-          printf '%s\n' \
-            '[Service]' \
-            'Environment=AWS_SHARED_CREDENTIALS_FILE=/run/nix-daemon-aws-credentials' \
-            | sudo tee /etc/systemd/system/nix-daemon.service.d/aws.conf >/dev/null
-          sudo systemctl daemon-reload
-          sudo systemctl restart nix-daemon.service
       - name: Build system closure
         id: build
         run: |
@@ -71,19 +56,14 @@ jobs:
             fi
             sleep "$((attempt * 15))"
           done
-      - name: Refresh AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+      - name: Refresh Nix daemon AWS credentials
+        # The default 1-hour STS session can expire during a long aarch64 build; refresh before
+        # uploading. The x86_64 legs build well within that window, so skip the extra assume-role
+        # round trip and daemon restart for them.
+        if: matrix.runner == 'ubuntu-24.04-arm'
+        uses: ./.github/actions/configure-nix-daemon-aws-creds
         with:
           role-to-assume: arn:aws:iam::481411455398:role/nixfiles-cache-publisher
-          aws-region: us-east-1
-          aws-profile: default
-          overwrite-aws-profile: true
-      - name: Refresh Nix daemon AWS credentials
-        run: |
-          sudo install -m 600 \
-            "$HOME/.aws/credentials" \
-            /run/nix-daemon-aws-credentials
-          sudo systemctl restart nix-daemon.service
       - name: Sign and push closure to S3
         run: |
           umask 077
@@ -105,6 +85,4 @@ jobs:
             --cache-control "no-cache"
       - name: Remove AWS credential files
         if: always()
-        run: |
-          rm -f "$HOME/.aws/credentials" "$HOME/.aws/config"
-          sudo rm -f /run/nix-daemon-aws-credentials
+        uses: ./.github/actions/cleanup-nix-daemon-aws-creds

--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -25,31 +25,14 @@ jobs:
             access-tokens = github.com=${{ secrets.KRYPTONIX_ACCESS_TOKEN }}
             extra-substituters = s3://thoughtfull-nix-cache?region=us-east-1 https://cache.numtide.com https://devenv.cachix.org
             extra-trusted-public-keys = nix-cache.thoughtfull.systems-1:kN4M+h0QLcDpQksBsFNtE9t6+bLa/s4axEWYpDmz2ag= niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g= devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+      - name: Configure Nix daemon AWS credentials
+        uses: ./.github/actions/configure-nix-daemon-aws-creds
         with:
           role-to-assume: arn:aws:iam::481411455398:role/nixfiles-cache-reader
-          aws-region: us-east-1
-          aws-profile: default
-          overwrite-aws-profile: true
-      - name: Configure Nix daemon AWS credentials
-        run: |
-          sudo mkdir -p /etc/systemd/system/nix-daemon.service.d
-          sudo install -m 600 \
-            "$HOME/.aws/credentials" \
-            /run/nix-daemon-aws-credentials
-          printf '%s\n' \
-            '[Service]' \
-            'Environment=AWS_SHARED_CREDENTIALS_FILE=/run/nix-daemon-aws-credentials' \
-            | sudo tee /etc/systemd/system/nix-daemon.service.d/aws.conf >/dev/null
-          sudo systemctl daemon-reload
-          sudo systemctl restart nix-daemon.service
       - name: Run devenv test
         run: nix develop --no-pure-eval --command devenv test
       - name: Run flake check
         run: nix flake check --no-pure-eval
       - name: Remove AWS credential files
         if: always()
-        run: |
-          rm -f "$HOME/.aws/credentials" "$HOME/.aws/config"
-          sudo rm -f /run/nix-daemon-aws-credentials
+        uses: ./.github/actions/cleanup-nix-daemon-aws-creds

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,25 +28,10 @@ jobs:
             access-tokens = github.com=${{ secrets.KRYPTONIX_ACCESS_TOKEN }}
             extra-substituters = s3://thoughtfull-nix-cache?region=us-east-1 https://cache.numtide.com https://devenv.cachix.org
             extra-trusted-public-keys = nix-cache.thoughtfull.systems-1:kN4M+h0QLcDpQksBsFNtE9t6+bLa/s4axEWYpDmz2ag= niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g= devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+      - name: Configure Nix daemon AWS credentials
+        uses: ./.github/actions/configure-nix-daemon-aws-creds
         with:
           role-to-assume: arn:aws:iam::481411455398:role/nixfiles-cache-reader
-          aws-region: us-east-1
-          aws-profile: default
-          overwrite-aws-profile: true
-      - name: Configure Nix daemon AWS credentials
-        run: |
-          sudo mkdir -p /etc/systemd/system/nix-daemon.service.d
-          sudo install -m 600 \
-            "$HOME/.aws/credentials" \
-            /run/nix-daemon-aws-credentials
-          printf '%s\n' \
-            '[Service]' \
-            'Environment=AWS_SHARED_CREDENTIALS_FILE=/run/nix-daemon-aws-credentials' \
-            | sudo tee /etc/systemd/system/nix-daemon.service.d/aws.conf >/dev/null
-          sudo systemctl daemon-reload
-          sudo systemctl restart nix-daemon.service
       - name: Build options-doc
         run: nix build .#options-doc
       - name: Upload artifact
@@ -55,9 +40,7 @@ jobs:
           path: result
       - name: Remove AWS credential files
         if: always()
-        run: |
-          rm -f "$HOME/.aws/credentials" "$HOME/.aws/config"
-          sudo rm -f /run/nix-daemon-aws-credentials
+        uses: ./.github/actions/cleanup-nix-daemon-aws-creds
   deploy:
     environment:
       name: github-pages

--- a/bin/finish-remote-provision.bash
+++ b/bin/finish-remote-provision.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+sudo loadkeys dvorak
+dumpkeys | sed 's/Caps_Lock/Control/' | sudo loadkeys
+nix run --refresh \
+  --extra-experimental-features 'nix-command flakes' \
+  "github:thoughtfull-nix/nixfiles/${BOOTSTRAP_GIT_BRANCH:-main}#nixfiles" -- \
+  finish-remote-provision \
+  "$@"

--- a/devenv.nix
+++ b/devenv.nix
@@ -29,6 +29,11 @@
     detect-private-keys.enable = true;
     eclint = {
       enable = true;
+      excludes = [
+        # .age secrets are raw binary ciphertext with no meaningful "final newline" or charset --
+        # eclint's fix mode would otherwise append a byte and corrupt them.
+        "\.age$"
+      ];
       settings.fix = true;
     };
     elisp-indent = {

--- a/doc/binary-cache.md
+++ b/doc/binary-cache.md
@@ -90,9 +90,10 @@ mode-`0600` default AWS profile without exporting credential environment
 variables. Each workflow copies that profile to a root-only file under
 `/run`, points `nix-daemon.service` at it with
 `AWS_SHARED_CREDENTIALS_FILE`, and restarts the daemon. Build and Push
-refreshes both copies after the build so an ARM build longer than the default
-one-hour STS session can still upload. An `always()` cleanup step removes both
-credential files when the job finishes.
+refreshes both copies after the build, but only on the aarch64 matrix leg,
+since that's the one long enough to occasionally outlast the default one-hour
+STS session; the x86_64 hosts build well within it. An `always()` cleanup
+step removes both credential files when the job finishes.
 
 The reader trust policy deliberately authorizes the repository's
 `pull_request` subject. PR jobs can therefore read the private cache but

--- a/nixosConfigurations/hydor.nix
+++ b/nixosConfigurations/hydor.nix
@@ -25,7 +25,7 @@
         thoughtfull = {
           claudeDesktop.enable = true;
           dev.enable = true;
-          githubToken.tokenFile = ../nixosConfigurations/shared/secrets/github-access-token.age;
+          githubToken.tokenFile = ./shared/secrets/github-access-token.age;
           graphical.enable = true;
           impermanence.disko = {
             boot.size = "512M";

--- a/nixosConfigurations/hydor.nix
+++ b/nixosConfigurations/hydor.nix
@@ -25,6 +25,7 @@
         thoughtfull = {
           claudeDesktop.enable = true;
           dev.enable = true;
+          githubToken.tokenFile = ../nixosConfigurations/shared/secrets/github-access-token.age;
           graphical.enable = true;
           impermanence.disko = {
             boot.size = "512M";

--- a/nixosModules/mako.nix
+++ b/nixosModules/mako.nix
@@ -27,8 +27,17 @@ let
     name = "mako-toggle-dnd";
     src = ./mako/toggle-dnd.bash;
   };
+  # `builtins.path` forces an independent, content-addressed copy of just this file into the
+  # store -- without it, this path literal instead resolves to a subpath of the flake's own
+  # whole-source checkout, which is never registered as a declared input anywhere it gets
+  # substituted in as text, so `makoConfig`'s embedded path ends up pointing at a path absent from
+  # `mako.package`'s actual runtime closure on any machine that doesn't separately already have
+  # this flake's source in its store.
   makoConfig = replaceVars ./mako/config {
-    notify = ./mako/notify.ogg;
+    notify = builtins.path {
+      path = ./mako/notify.ogg;
+      name = "notify.ogg";
+    };
   };
 in
 {

--- a/overlays/thoughtfull.nix
+++ b/overlays/thoughtfull.nix
@@ -55,7 +55,16 @@ let
   writeArgcScript =
     name: src: replacements:
     let
-      bashlib = ./write-argc-script/bashlib.bash;
+      # `builtins.path` forces an independent, content-addressed copy of just this file. Without
+      # it, this path literal instead resolves to a subpath of the flake's own whole-source
+      # checkout, which is never registered as a declared input anywhere it gets substituted in
+      # as text -- so the built script's `source` line ends up pointing at a path that's absent
+      # from the package's actual runtime closure on any machine that doesn't separately already
+      # have this flake's source in its store.
+      bashlib = builtins.path {
+        path = ./write-argc-script/bashlib.bash;
+        name = "bashlib.bash";
+      };
       prefix = replaceVars ./write-argc-script/prefix.bash {
         bash = getExe bash;
         bashlib = bashlib;

--- a/overlays/write-argc-script/bashlib.bash
+++ b/overlays/write-argc-script/bashlib.bash
@@ -174,11 +174,14 @@ find-dominating-file() {
 ## Arguments:
 ## n :: number of lines before the cursor position to clear, defaults to 1
 clear-lines() {
-  tput cr
-  tput el
+  # tput fails (and, under `set -e`, would otherwise abort the whole script) when there's no
+  # terminal, e.g. under non-interactive/scripted invocation; clearing lines is cosmetic, so skip
+  # it silently in that case rather than aborting.
+  tput cr || return 0
+  tput el || return 0
   for ((i = 1; i < ${1:-1}; i++)); do
-    tput cuu1
-    tput el
+    tput cuu1 || return 0
+    tput el || return 0
   done
   return 0
 }

--- a/packages/dictation.nix
+++ b/packages/dictation.nix
@@ -15,12 +15,24 @@ makeOverridable
     writeFileScriptBin {
       name = "dictation";
       replacements = {
-        cancel-sound = ./dictation/cancel.wav;
+        # `builtins.path` forces an independent, content-addressed copy of just this file into the
+        # store -- without it, this path literal instead resolves to a subpath of the flake's own
+        # whole-source checkout, which is never registered as a declared input anywhere it gets
+        # substituted in as text, so the built script's `source`-relative reference ends up
+        # pointing at a path absent from the package's actual runtime closure on any machine that
+        # doesn't separately already have this flake's source in its store.
+        cancel-sound = builtins.path {
+          path = ./dictation/cancel.wav;
+          name = "cancel.wav";
+        };
         model = toString modelFile;
         notify-send = "${libnotify}/bin/notify-send";
         play = "${sox}/bin/play";
         recbin = "${sox}/bin/rec";
-        start-sound = ./dictation/start.wav;
+        start-sound = builtins.path {
+          path = ./dictation/start.wav;
+          name = "start.wav";
+        };
         whisper = "${whisper-cpp}/bin/whisper-cli";
         wtype = "${wtype}/bin/wtype";
       };

--- a/packages/nixfiles.bash
+++ b/packages/nixfiles.bash
@@ -19,7 +19,10 @@ TMPDIR="$(mktemp -d)"
 addtrap "log \"Recursively deleting ${TMPDIR}\""
 log "Using temporary directory ${TMPDIR}"
 
-GPG_TTY=$(tty)
+# `tty` fails (and, under `set -e`, would otherwise abort the whole script) when there's no
+# controlling terminal, e.g. under non-interactive/scripted invocation.  GPG_TTY is only needed
+# for interactive Yubikey/pinentry prompts, so leaving it empty in that case is harmless.
+GPG_TTY=$(tty 2>/dev/null || true)
 export GPG_TTY
 
 GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=accept-new"
@@ -135,26 +138,270 @@ provision() {
   # == Ensure host configuration
   log "Ensure host configuration"
   if [[ ! -e "${host_path}.nix" ]]; then
-    log "Initializing NixOS configuration"
-    sed "s/BOOTSTRAP/${argc_hostname}/g" \
-      <"${nixos_configs_path}/bootstrap.nix" \
-      >"${host_path}.nix" ||
-      die "Failed to initialize NixOS configuration"
+    init-host-config-file
   fi
   # == Ensure hardware configuration
+  ensure-hardware-config
+  # == Ensure passphrases
+  ensure-luks-recovery-passphrase-file
+  ensure-hashed-user-passphrase
+  # == Ensure partitions
+  log "Ensure partitions"
+  ensure-partitions
+  ensure-fido2-enrollment
+  # == Ensure SSH host key
+  host_key_path="/mnt/persistent/etc/ssh/ssh_host_ed25519_key"
+  log "Ensure SSH host key"
+  if [[ ! -e ${host_key_path} ]]; then
+    log "Generating SSH host key"
+    sudo mkdir -p "$(dirname "${host_key_path}")" ||
+      die "Failed to create host key parent directory"
+    sudo ssh-keygen -f "${host_key_path}" -C "${argc_hostname} SSH host key" -N "" -t "ed25519" ||
+      die "Failed to generate SSH host key: ${host_key_path}"
+    cp "${host_key_path}.pub" "${host_path}/" ||
+      die "Failed to copy host public key"
+    rekey ||
+      die "Failed to rekey secrets"
+  fi
+  commit-and-push
+  ## - if persistent is empty (except for ssh key?), restore from restic
+  run-nixos-install
+}
+
+## @cmd Provision a remote work machine from this (personal) laptop, over SSH.
+##
+## Runs entirely on this laptop, which is assumed to already have git, GPG, and a Yubikey signing
+## key configured -- unlike `provision`, this never sets any of that up, and never sends a commit
+## or push credential, or a GPG signing key, to the target.
+##
+## The target is SSHed into only for the handful of things that must run on its real hardware:
+## generating an accurate hardware-configuration.nix, and delivering the target's new SSH host
+## private key directly.  Everything else (secret generation, disk-option prompts, the commit and
+## push) happens locally.
+##
+## Once this pushes, finish the install by running `finish-remote-provision` directly on the
+## target's own console.
+##
+## @arg hostname!
+## name of host to provision
+##
+## @arg target!
+## user@host of the target machine, already booted and reachable over ssh
+##
+## @option --nixfiles-git-branch=main $$
+## branch to commit and push to
+##
+## @option --age-identity $$
+## private key used to decrypt secrets, needed to rekey shared secrets for the new host
+##
+## @option --disk-device $$
+## block device to partition and encrypt on the target, e.g. /dev/nvme0n1 -- prompted for if unset
+##
+## @option --boot-size=1G $$
+## size of the EFI boot partition
+##
+## @option --swap-size $$
+## size of the swap file -- prompted for if unset
+##
+## @option --extra-secret* $$
+## additional secret name(s) to prompt for and encrypt now (e.g. an aws-secret-key)
+remote-provision() {
+  argc_age_identity=${argc_age_identity:-${argc_nixfiles_path}/master-identities.txt}
+  master_recipients="${argc_nixfiles_path}/master-recipients.txt"
+  nixos_configs_path="${argc_nixfiles_path}/nixosConfigurations"
+  host_path="${nixos_configs_path}/${argc_hostname}"
+  secrets_path="${host_path}/secrets"
+  git_opts=(-C "${argc_nixfiles_path}")
+
+  [[ -d ${argc_nixfiles_path} ]] ||
+    die "nixfiles path does not exist: ${argc_nixfiles_path}"
+
+  log "Verifying ssh connectivity to ${argc_target}"
+  remote true || die "Cannot SSH to ${argc_target}"
+
+  log "Ensure correct branch is checked out"
+  if ! git branch --show-current | grep -qx "${argc_nixfiles_git_branch}"; then
+    git checkout "${argc_nixfiles_git_branch}" ||
+      die "Failed to checkout git branch: ${argc_nixfiles_git_branch}"
+  fi
+
+  # == Ensure host configuration
+  log "Ensure host configuration"
+  if [[ ! -e "${host_path}.nix" ]]; then
+    init-host-config-file
+    log "Filling in disk configuration"
+    disk_device=${argc_disk_device:-}
+    if [[ -z ${disk_device} ]]; then
+      log "Target disk layout:"
+      remote lsblk -dno NAME,SIZE,TYPE || true
+      ask "Boot disk device (e.g. /dev/nvme0n1): " disk_device
+    fi
+    swap_size=${argc_swap_size:-}
+    if [[ -z ${swap_size} ]]; then
+      ask "Swap size (e.g. 4G): " swap_size
+    fi
+    sed -i \
+      -e "s|# boot.size = \"1G\";|boot.size = \"${argc_boot_size}\";|" \
+      -e "s|# encrypted.device = \"/dev/nvme0n1\";|encrypted.device = \"${disk_device}\";|" \
+      -e "s|# swap.size = \"4G\";|swap.size = \"${swap_size}\";|" \
+      "${host_path}.nix" ||
+      die "Failed to fill in disk configuration"
+  fi
+
+  # == Ensure hardware configuration, generated over ssh
+  ensure-hardware-config remote
+
+  # == Ensure SSH host keypair, generated locally and delivered directly to the target
+  log "Ensure SSH host keypair"
+  if [[ ! -r "${host_path}/ssh_host_ed25519_key.pub" ]]; then
+    log "Generating SSH host keypair locally"
+    host_key_tmpdir=$(mktemp -d)
+    addtrap "rm -rf ${host_key_tmpdir}"
+    ssh-keygen -f "${host_key_tmpdir}/ssh_host_ed25519_key" \
+      -C "${argc_hostname} SSH host key" -N "" -t ed25519 ||
+      die "Failed to generate SSH host key"
+    cp "${host_key_tmpdir}/ssh_host_ed25519_key.pub" "${host_path}/ssh_host_ed25519_key.pub" ||
+      die "Failed to copy host public key"
+    log "Delivering private host key directly to target"
+    remote 'umask 077 && cat >/tmp/ssh_host_ed25519_key' \
+      <"${host_key_tmpdir}/ssh_host_ed25519_key" ||
+      die "Failed to deliver ssh host key to target"
+    rm -rf "${host_key_tmpdir}"
+  fi
+
+  # == Ensure passphrases (write-only for a brand-new host, no decryption needed)
+  ensure-secret "LUKS recovery passphrase"
+  unset luks_recovery_passphrase
+  ensure-hashed-user-passphrase
+  for extra_secret in "${argc_extra_secret[@]:-}"; do
+    [[ -n ${extra_secret} ]] || continue
+    ensure-secret "${extra_secret}" prompt
+  done
+
+  # == Extend shared secrets (e.g. the github access token) to include the new host
+  log "Rekeying shared secrets for the new host"
+  rekey "${argc_hostname}" ||
+    die "Failed to rekey secrets"
+
+  commit-and-push
+
+  # == Print the exact command to finish provisioning on the target's own console
+  github_repo=$(git remote get-url origin |
+    sed -E 's#^(git@github\.com:|https://github\.com/)##; s#\.git$##')
+  finish_url="https://raw.githubusercontent.com/${github_repo}/refs/heads/${argc_nixfiles_git_branch}/bin/finish-remote-provision.bash"
+  log "Next: on ${argc_target}'s own console, run:"
+  cat <<EXAMPLE
+
+  NIXFILES_GIT_BRANCH=${argc_nixfiles_git_branch} BOOTSTRAP_GIT_BRANCH=${argc_nixfiles_git_branch} \\
+    bash <(curl -fsSL ${finish_url}) ${argc_hostname}
+
+EXAMPLE
+}
+
+## @cmd Finish provisioning a remote work machine, run directly on the target's own console.
+##
+## Run this on the work machine itself (e.g. via `nix run
+## github:thoughtfull-nix/nixfiles#nixfiles -- finish-remote-provision <hostname>`) after
+## `remote-provision` has pushed its configuration and delivered this host's SSH private key to
+## /tmp.  Clones the (public) nixfiles repository read-only, decrypts the shared github access
+## token and this host's own secrets using that key, then formats disks, enrolls FIDO2, and
+## installs NixOS.  Never needs git commit access, a GPG key, or the Yubikey master age identity.
+##
+## @arg hostname!
+## name of host to finish provisioning
+##
+## @option --nixfiles-git-url=https://github.com/thoughtfull-nix/nixfiles.git $$
+## URL to clone the nixfiles repository from (read-only -- no credentials needed for a public repo)
+##
+## @option --nixfiles-git-branch=main $$
+## branch to clone
+finish-remote-provision() {
+  host_key_path=/tmp/ssh_host_ed25519_key
+  sudo test -e "${host_key_path}" ||
+    die "Missing ${host_key_path} -- run remote-provision from your personal laptop first"
+  # remote-provision delivers this over ssh as whichever user it targeted (typically root), mode
+  # 0600 -- reclaim it for the current user so age and everything else below can read it without
+  # needing sudo on every single access.
+  sudo chown "$(id -u):$(id -g)" "${host_key_path}" ||
+    die "Failed to take ownership of ${host_key_path}"
+  sudo chmod 600 "${host_key_path}" ||
+    die "Failed to set permissions on ${host_key_path}"
+
+  argc_nixfiles_path=$(mktemp -d)
+  addtrap "rm -rf ${argc_nixfiles_path}"
+  log "Cloning nixfiles repository"
+  @git@ clone --branch "${argc_nixfiles_git_branch}" "${argc_nixfiles_git_url}" "${argc_nixfiles_path}" ||
+    die "Failed to clone nixfiles repo: ${argc_nixfiles_git_url}"
+
+  argc_age_identity=${host_key_path}
+  master_recipients="${argc_nixfiles_path}/master-recipients.txt"
+  nixos_configs_path="${argc_nixfiles_path}/nixosConfigurations"
+  host_path="${nixos_configs_path}/${argc_hostname}"
+  secrets_path="${host_path}/secrets"
+
+  # == Fetch the github access token before evaluating the flake at all: nixosConfigurations.nix
+  # references the private kryptonix flake input unconditionally, so even `disko --mode mount`
+  # would otherwise fail to fetch it.  /etc/nix/nix.conf is a symlink into the (read-only) Nix
+  # store on any standard NixOS system, so it can't be appended to.  Write it to root's own
+  # writable per-user nix.conf instead (disko/nixos-install below all run as root via sudo) --
+  # this is read directly by any nix invocation running as root, with no dependency on an
+  # environment variable surviving sudo or whatever a tool like disko does internally.
+  log "Fetching github access token"
+  # This secret's decrypted content is already a complete nix.conf line (e.g.
+  # "access-tokens = github.com=ghp_xxx"), matching how nixosModules/github-token.nix consumes
+  # it via `!include` -- write it in as-is, don't re-wrap it in another access-tokens prefix.
+  sudo mkdir -p /root/.config/nix ||
+    die "Failed to create /root/.config/nix"
+  age -d -i "${host_key_path}" \
+    "${nixos_configs_path}/shared/secrets/github-access-token.age" |
+    sudo tee /root/.config/nix/nix.conf >/dev/null ||
+    die "Failed to write github access token to /root/.config/nix/nix.conf"
+
+  # == Ensure partitions
+  ensure-luks-recovery-passphrase-file
+  ensure-partitions
+
+  # == Install the ssh host key now that persistent is mounted
+  log "Installing SSH host key"
+  sudo install -D -m 600 "${host_key_path}" /mnt/persistent/etc/ssh/ssh_host_ed25519_key ||
+    die "Failed to install ssh host key"
+  sudo install -D -m 644 "${host_path}/ssh_host_ed25519_key.pub" \
+    /mnt/persistent/etc/ssh/ssh_host_ed25519_key.pub ||
+    die "Failed to install ssh host public key"
+
+  ensure-fido2-enrollment
+
+  run-nixos-install
+}
+
+## Initialize ${host_path}.nix from the bootstrap.nix template, with BOOTSTRAP replaced by
+## ${argc_hostname}.  Caller is responsible for checking whether the file already exists.
+init-host-config-file() {
+  log "Initializing NixOS configuration"
+  sed "s/BOOTSTRAP/${argc_hostname}/g" \
+    <"${nixos_configs_path}/bootstrap.nix" \
+    >"${host_path}.nix" ||
+    die "Failed to initialize NixOS configuration"
+}
+
+## Ensure ${host_path}/hardware-configuration.nix exists, generating it with
+## nixos-generate-config if missing.  If $1 is given, it's used as a command prefix to run the
+## generator through (e.g. `remote`, to run it over ssh on the `remote-provision` target) instead
+## of running it directly on this machine.
+ensure-hardware-config() {
   log "Ensure hardware configuration"
   # shellcheck disable=SC2024
   if [[ ! -r "${host_path}/hardware-configuration.nix" ]]; then
-    log "Generating hardware configuration in repository"
+    log "Generating hardware configuration${1:+ over ssh}"
     mkdir -p "${host_path}"
-    sudo nixos-generate-config \
-      --no-filesystems \
-      --show-hardware-config \
+    ${1:+"$1"} sudo nixos-generate-config --no-filesystems --show-hardware-config \
       >"${host_path}/hardware-configuration.nix" ||
       die "Failed to generate hardware configuration"
   fi
-  # == Ensure passphrases
-  ensure-passphrase "LUKS recovery passphrase"
+}
+
+## Ensure the hashed user login passphrase secret exists, generating and encrypting one if not.
+ensure-hashed-user-passphrase() {
   if [[ ! -r "${secrets_path}/hashed-user-passphrase.age" ]]; then
     log "Hashing user passphrase"
     user_passphrase=$(phraze)
@@ -165,12 +412,21 @@ provision() {
     printf "Generated user passphrase: %s\n" "${user_passphrase//?/*}"
     unset user_passphrase
   fi
-  # == Ensure partitions
-  log "Ensure partitions"
-  # needed for mounting and/or formatting
+}
+
+## Ensure the LUKS recovery passphrase secret exists, then stage it at
+## /tmp/luks-recovery-passphrase.txt for disko to consume when formatting/mounting.
+ensure-luks-recovery-passphrase-file() {
+  ensure-secret "LUKS recovery passphrase"
   echo -n "${luks_recovery_passphrase}" >/tmp/luks-recovery-passphrase.txt ||
     die "Failed to write password file"
   unset luks_recovery_passphrase
+}
+
+## Mount the target's partitions, formatting them first (with confirmation) if they don't exist
+## yet.  Expects /tmp/luks-recovery-passphrase.txt to already be in place, and
+## ${argc_nixfiles_path}/${argc_hostname} to be set.
+ensure-partitions() {
   if ! sudo @disko@ --mode mount --flake "${argc_nixfiles_path}#${argc_hostname}"; then
     log "Partitions not found"
     error "Formatting disks, data could be permanently lost!"
@@ -184,7 +440,11 @@ provision() {
       install-rpi4-firmware
     fi
   fi
-  # == Ensure systemd FIDO2 enrollment (non-rpi4)
+}
+
+## Enroll the LUKS partition with FIDO2, prompting to swap primary/backup devices.  Skipped on
+## aarch64/RPi4 (no FIDO2 enrollment there).
+ensure-fido2-enrollment() {
   if [[ "$(uname -m)" != "aarch64" ]]; then
     log "Ensure systemd FIDO2 enrollment"
     luks_device=$(sudo blkid -t TYPE=crypto_LUKS -o device -l)
@@ -203,21 +463,10 @@ provision() {
       pause
     fi
   fi
-  # == Ensure SSH host key
-  host_key_path="/mnt/persistent/etc/ssh/ssh_host_ed25519_key"
-  log "Ensure SSH host key"
-  if [[ ! -e ${host_key_path} ]]; then
-    log "Generating SSH host key"
-    sudo mkdir -p "$(dirname "${host_key_path}")" ||
-      die "Failed to create host key parent directory"
-    sudo ssh-keygen -f "${host_key_path}" -C "${argc_hostname} SSH host key" -N "" -t "ed25519" ||
-      die "Failed to generate SSH host key: ${host_key_path}"
-    cp "${host_key_path}.pub" "${host_path}/" ||
-      die "Failed to copy host public key"
-    rekey ||
-      die "Failed to rekey secrets"
-  fi
-  # == Commit and push changes
+}
+
+## Commit and push any staged changes in ${argc_nixfiles_path}, if there are any.
+commit-and-push() {
   git add .
   if ! git diff-index --cached --quiet HEAD; then
     log "Commit and push changes"
@@ -225,34 +474,59 @@ provision() {
     git status ||
       die "Failed to check git status"
     confirm
+    commit_attempts=0
     while ! git commit -m "Provision ${argc_hostname}"; do
+      commit_attempts=$((commit_attempts + 1))
+      # A commit can fail because a pre-commit hook modified a file (e.g. a formatter fixup) --
+      # re-stage before retrying so that fix actually gets included.  Cap retries so a
+      # persistently failing hook (or a GPG card that never gets inserted) doesn't loop forever.
+      ((commit_attempts < 5)) ||
+        die "Failed to commit changes after ${commit_attempts} attempts"
       echo "Failed to commit changes.  Trying again"
+      git add .
     done
     git push origin "${argc_nixfiles_git_branch}" ||
       die "Failed to push changes"
   fi
-  ## - if persistent is empty (except for ssh key?), restore from restic
+}
+
+## Install NixOS onto the mounted target.
+run-nixos-install() {
   log "Install NixOS"
-  sudo nixos-install --flake "${argc_nixfiles_path}#${argc_hostname}" --no-root-password ||
+  sudo nixos-install \
+    --flake "${argc_nixfiles_path}#${argc_hostname}" --no-root-password ||
     die "Failed to install NixOS"
 }
 
-ensure-passphrase() {
+## Ensure a secret exists, either by decrypting it (if already encrypted for this host), prompting
+## the user for it, or generating a random one -- then encrypting it.
+##
+## Arguments:
+## name :: human-readable name of the secret, e.g. "LUKS recovery passphrase"
+## mode :: "generate" (default) to generate a random value via phraze, or "prompt" to ask the
+##         user to type/paste one in (e.g. for an AWS key)
+ensure-secret() {
   name=$1
+  mode=${2:-generate}
   secret_name=${1,,}
   secret_name=${secret_name// /-}
-  local -n passphrase=${secret_name//-/_}
+  local -n secret_value=${secret_name//-/_}
   if [[ -r "${secrets_path}/${secret_name}.age" ]]; then
-    passphrase=$(age-decrypt "${secret_name}")
+    secret_value=$(age-decrypt "${secret_name}")
+  elif [[ ${mode} == "prompt" ]]; then
+    whisper "Enter value for ${name}: " secret_value
+    [[ -n ${secret_value} ]] ||
+      die "${name} is empty"
+    age-encrypt "${secret_name}" <(printf '%s' "${secret_value}")
   else
-    passphrase=$(phraze)
-    age-encrypt "${secret_name}" <(echo -n "${passphrase}")
-    printf "Generated ${name}: %s\n" "${passphrase}"
+    secret_value=$(phraze)
+    age-encrypt "${secret_name}" <(echo -n "${secret_value}")
+    printf "Generated ${name}: %s\n" "${secret_value}"
     pause "Press any key to continue (and clear the passphrase)"
     clear-lines 2
-    printf "Generated ${name}: %s\n" "${passphrase//?/*}"
+    printf "Generated ${name}: %s\n" "${secret_value//?/*}"
   fi
-  [[ -n ${passphrase} ]] ||
+  [[ -n ${secret_value} ]] ||
     die "${name} is empty"
 }
 
@@ -434,6 +708,13 @@ rekey() {
 
 _default-hostname() {
   hostname -s
+}
+
+## Run a command over ssh on the `remote-provision` target.  StrictHostKeyChecking is
+## `accept-new` (trust-on-first-use) rather than disabled outright, since the target is a
+## freshly-booted, single-use machine but still worth pinning for the duration of the connection.
+remote() {
+  ssh -o StrictHostKeyChecking=accept-new "${argc_target}" "$@"
 }
 
 # Install Raspberry Pi 4 firmware and U-Boot for USB boot

--- a/tests.nix
+++ b/tests.nix
@@ -19,6 +19,7 @@ forEachSystem (
     dev = callTest ./tests/dev.nix;
     github-token = callTest ./tests/github-token.nix;
     graphical = callTest ./tests/graphical.nix;
+    nixfiles = callTest ./tests/nixfiles.nix;
     system-pull = callTest ./tests/system-pull.nix;
     waybar = callTest ./tests/waybar.nix;
   }

--- a/tests/nixfiles.nix
+++ b/tests/nixfiles.nix
@@ -1,0 +1,454 @@
+{ self, nixpkgs, ... }:
+let
+  # Overlays applied directly (not via the `nixpkgs.overlays` module option) so the same `pkgs`
+  # can also build fixture derivations (a custom `nixfiles` build with stubbed disko, an SSH
+  # test keypair, a pre-encrypted shared secret) outside of any node.
+  pkgs = nixpkgs.extend self.overlays.thoughtfull;
+  inherit (pkgs) lib;
+
+  # SSH keypair so `personal` can reach `target` without a real Yubikey/ssh-agent.
+  testSshKey = pkgs.runCommand "test-ssh-key" { nativeBuildInputs = [ pkgs.openssh ]; } ''
+    mkdir -p $out
+    ssh-keygen -t ed25519 -N "" -C "test" -f $out/id_ed25519
+  '';
+
+  # Stand-in for master-recipients.txt / master-identities.txt. `remote-provision` only ever
+  # *encrypts* against master-recipients.txt in this flow (LUKS/user passphrase secrets are
+  # write-only for a brand-new host) -- the identity half is never exercised here.
+  testAgeKey = pkgs.runCommand "test-age-key" { nativeBuildInputs = [ pkgs.age ]; } ''
+    mkdir -p $out
+    age-keygen -o $out/identity.txt 2>$out/keygen.log
+    grep "Public key:" $out/keygen.log | sed 's/.*Public key: //' >$out/recipient.txt
+  '';
+
+  # A pre-existing shared secret, standing in for a repo that already has other hosts.
+  # `remote-provision`'s `rekey <hostname>` call must re-encrypt this to include the new host's
+  # pubkey, so `finish-remote-provision` can later decrypt it using *only* the host's own
+  # just-installed key -- never the master identity.
+  #
+  # The decrypted content is a complete nix.conf line (matching how nixosModules/github-token.nix
+  # consumes it via `!include`), not a bare token -- finish-remote-provision writes it into
+  # /root/.config/nix/nix.conf as-is.
+  fakeGithubToken = "ghp_faketoken0000000000000000000000";
+  fakeGithubTokenLine = "access-tokens = github.com=${fakeGithubToken}";
+  githubTokenSecret =
+    pkgs.runCommand "github-access-token.age"
+      {
+        nativeBuildInputs = [ pkgs.age ];
+      }
+      ''
+        echo -n "${fakeGithubTokenLine}" | age -e -R ${testAgeKey}/recipient.txt -o $out
+      '';
+
+  bootstrapNixFile = pkgs.writeText "bootstrap.nix" (
+    builtins.readFile ../nixosConfigurations/bootstrap.nix
+  );
+
+  # Record disko's invocation instead of touching a real disk. Fails loudly if the github access
+  # token hasn't already been written by that point -- this is the ordering
+  # `finish-remote-provision` must get right, since evaluating any nixosConfigurations.<host>
+  # (which a real `disko --mode ... --flake ...#<host>` would do) forces a fetch of the private
+  # `kryptonix` flake input. (/etc/nix/nix.conf is a symlink into the read-only Nix store on any
+  # NixOS system, so the token goes to root's own writable /root/.config/nix/nix.conf instead --
+  # this stub always runs as root via sudo, same as the real disko/nixos-install invocations.)
+  stubDisko = pkgs.writeShellScriptBin "disko" ''
+    echo "disko $*" >>/tmp/stub-calls.log
+    grep -q "access-tokens.*github.com" /root/.config/nix/nix.conf 2>/dev/null || {
+      echo "disko stub: github token missing from /root/.config/nix/nix.conf at disko time" >&2
+      exit 1
+    }
+    exit 0
+  '';
+
+  # Placeholders shared by every `nixfiles` test build; each build below overrides only the
+  # handful of commands (disko, gpg, ssh-add) it needs to stub differently.
+  commonNixfilesArgs = {
+    age = "${pkgs.age}/bin/age";
+    git = "${pkgs.git}/bin/git";
+    gpgconf = "${pkgs.gnupg}/bin/gpgconf";
+    phraze = "${pkgs.phraze}/bin/phraze";
+    pinentry = "${pkgs.pinentry-tty}/bin/pinentry-tty";
+    raspberrypi-firmware = "";
+    ssh-agent = "${pkgs.openssh}/bin/ssh-agent";
+    uboot-rpi4 = "";
+  };
+
+  testNixfiles = pkgs.thoughtfull.writeArgcScript "nixfiles" ../packages/nixfiles.bash (
+    commonNixfilesArgs
+    // {
+      disko = "${stubDisko}/bin/disko";
+      gpg = "${pkgs.gnupg}/bin/gpg";
+      ssh-add = "${pkgs.openssh}/bin/ssh-add";
+    }
+  );
+
+  # `provision` bootstraps a GPG signing key off a Yubikey smartcard and loads a resident SSH key
+  # via `ssh-add -K` -- neither is available in a VM. Stub both: `gpg -k`/`-K` just need to report
+  # the hardcoded `gpg_key` ("DF2034C6") as already loaded so the fetch-key/insert-card loop is
+  # skipped entirely, and `ssh-add -K` just needs to succeed. Actual GPG commit signing is avoided
+  # separately, by pre-seeding an already-existing (not freshly cloned) repo checkout below, so
+  # `commit.gpgsign` never gets enabled in the first place.
+  stubGpg = pkgs.writeShellScriptBin "gpg" ''
+    echo "DF2034C6"
+    exit 0
+  '';
+
+  stubSshAdd = pkgs.writeShellScriptBin "ssh-add" ''
+    exit 0
+  '';
+
+  # `provision` (unlike `finish-remote-provision`) never writes a github access token anywhere --
+  # it has no equivalent token-forwarding step of its own -- so it needs a disko stub without
+  # that check.
+  stubDiskoForProvision = pkgs.writeShellScriptBin "disko" ''
+    echo "disko $*" >>/tmp/stub-calls.log
+    exit 0
+  '';
+
+  testNixfilesForProvision = pkgs.thoughtfull.writeArgcScript "nixfiles" ../packages/nixfiles.bash (
+    commonNixfilesArgs
+    // {
+      disko = "${stubDiskoForProvision}/bin/disko";
+      gpg = "${stubGpg}/bin/gpg";
+      ssh-add = "${stubSshAdd}/bin/ssh-add";
+    }
+  );
+
+  # Stub the handful of destructive/hardware-specific commands `finish-remote-provision`
+  # dispatches on the target, so the test exercises the script's own orchestration logic
+  # (sequencing, file placement, secret handling) without a real disk or a fully-evaluable flake.
+  # `lib.hiPrio` ensures these win over anything else that might land on PATH.
+  stubNixosGenerateConfig = lib.hiPrio (
+    pkgs.writeShellScriptBin "nixos-generate-config" ''
+      cat <<'HWCONFIG'
+      { modulesPath, ... }:
+      {
+        imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
+        boot.initrd.availableKernelModules = [ "virtio_pci" "virtio_blk" ];
+        nixpkgs.hostPlatform = "x86_64-linux";
+      }
+      HWCONFIG
+    ''
+  );
+
+  stubNixosInstall = lib.hiPrio (
+    pkgs.writeShellScriptBin "nixos-install" ''
+      echo "nixos-install $*" >>/tmp/stub-calls.log
+      exit 0
+    ''
+  );
+
+  stubCryptenroll = lib.hiPrio (
+    pkgs.writeShellScriptBin "systemd-cryptenroll" ''
+      echo "systemd-cryptenroll $*" >>/tmp/stub-calls.log
+      echo fido2
+      exit 0
+    ''
+  );
+
+  stubBlkid = lib.hiPrio (
+    pkgs.writeShellScriptBin "blkid" ''
+      echo "/dev/vdb2"
+    ''
+  );
+in
+pkgs.testers.nixosTest {
+  name = "nixfiles";
+
+  skipTypeCheck = true;
+  skipLint = true;
+
+  nodes = {
+    # Stands in for the already-configured personal laptop: git identity is set up, but
+    # deliberately no GPG signing key/Yubikey -- `remote-provision` must not need one.
+    personal =
+      { ... }:
+      {
+        environment.systemPackages = [
+          testNixfiles
+          pkgs.git
+          pkgs.whois # mkpasswd, used by ensure-secret for the hashed user passphrase
+        ];
+        services.openssh.enable = true;
+      };
+
+    # Stands in for the work laptop, booted from a vanilla NixOS ISO and reachable over SSH
+    # (console `passwd`/authorized_keys step already done). Also serves the fixture repo
+    # anonymously over git://, standing in for a public GitHub clone.
+    target =
+      { ... }:
+      {
+        environment.systemPackages = [
+          testNixfiles
+          pkgs.age
+          pkgs.git
+          stubNixosGenerateConfig
+          stubNixosInstall
+          stubCryptenroll
+          stubBlkid
+        ];
+        services.openssh = {
+          enable = true;
+          settings.PermitRootLogin = "yes";
+        };
+        users.users.root.openssh.authorizedKeys.keyFiles = [ "${testSshKey}/id_ed25519.pub" ];
+        # remote-provision's ssh delivery lands the host key as root (0600); finish-remote-provision
+        # is run by a different, unprivileged console user here (matching a real installer login),
+        # to catch ownership mismatches on that handoff.
+        users.users.operator = {
+          isNormalUser = true;
+          extraGroups = [ "wheel" ];
+        };
+        security.sudo.wheelNeedsPassword = false;
+        # git-daemon.service needs /srv/git to exist at boot; the bare repo itself is created
+        # later in the test script.
+        systemd.tmpfiles.rules = [ "d /srv/git 0755 root root - -" ];
+        services.gitDaemon = {
+          enable = true;
+          basePath = "/srv/git";
+          exportAll = true;
+        };
+        # git-daemon runs as its own unprivileged user; without this it refuses to serve a
+        # repository owned by root (the "detected dubious ownership" safe.directory check).
+        environment.etc."gitconfig".text = ''
+          [safe]
+            directory = /srv/git/nixfiles.git
+        '';
+      };
+
+    # Stands in for the fully-console-based `provision` flow: everything (Yubikey/GPG bootstrap
+    # stubbed, disk formatting, commit, install) happens on one machine, no personal laptop or
+    # network involved.
+    standalone =
+      { ... }:
+      {
+        environment.systemPackages = [
+          testNixfilesForProvision
+          pkgs.age
+          pkgs.git
+          pkgs.whois # mkpasswd, used by ensure-secret for the hashed user passphrase
+          stubNixosGenerateConfig
+          stubNixosInstall
+          stubCryptenroll
+          stubBlkid
+        ];
+      };
+  };
+
+  testScript = ''
+    start_all()
+    personal.wait_for_unit("multi-user.target")
+    target.wait_for_unit("sshd.service")
+    target.wait_for_unit("git-daemon.service")
+    standalone.wait_for_unit("multi-user.target")
+
+    with subtest("personal can reach target over ssh"):
+        personal.succeed("mkdir -p -m 700 /root/.ssh")
+        personal.copy_from_host("${testSshKey}/id_ed25519", "/root/.ssh/id_ed25519")
+        personal.succeed("chmod 600 /root/.ssh/id_ed25519")
+        personal.succeed(
+            "ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes root@target true"
+        )
+
+    with subtest("seed the fixture repo, standing in for an existing nixfiles checkout"):
+        target.succeed("git init --bare /srv/git/nixfiles.git")
+        personal.succeed(
+            "git init -b main /root/nixfiles-fixture && "
+            "git -C /root/nixfiles-fixture config user.name test && "
+            "git -C /root/nixfiles-fixture config user.email test@example.com && "
+            "mkdir -p /root/nixfiles-fixture/nixosConfigurations/shared/secrets"
+        )
+        personal.copy_from_host(
+            "${bootstrapNixFile}", "/root/nixfiles-fixture/nixosConfigurations/bootstrap.nix"
+        )
+        personal.copy_from_host(
+            "${testAgeKey}/recipient.txt", "/root/nixfiles-fixture/master-recipients.txt"
+        )
+        personal.copy_from_host("${testAgeKey}/identity.txt", "/root/master-identity.txt")
+        personal.copy_from_host(
+            "${githubTokenSecret}",
+            "/root/nixfiles-fixture/nixosConfigurations/shared/secrets/github-access-token.age",
+        )
+        personal.succeed(
+            "git -C /root/nixfiles-fixture add . && "
+            "git -C /root/nixfiles-fixture commit -m 'seed fixture' && "
+            "git -C /root/nixfiles-fixture remote add origin root@target:/srv/git/nixfiles.git && "
+            "git -C /root/nixfiles-fixture push origin HEAD:main"
+        )
+
+    with subtest("remote-provision runs entirely from personal, dispatching over ssh to target"):
+        log = personal.succeed(
+            "(yes yes || true) | nixfiles remote-provision test-host root@target "
+            "--nixfiles-path=/root/nixfiles-fixture --nixfiles-git-branch=main "
+            "--age-identity=/root/master-identity.txt "
+            "--disk-device=/dev/vdb --boot-size=512M --swap-size=1G "
+            "2>&1"
+        )
+        print(f"remote-provision output:\n{log}")
+
+    with subtest("a real (stubbed) hardware-configuration.nix was generated over ssh, not locally"):
+        hwconfig = personal.succeed(
+            "cat /root/nixfiles-fixture/nixosConfigurations/test-host/hardware-configuration.nix"
+        )
+        print(f"hardware-configuration.nix:\n{hwconfig}")
+        assert "virtio_blk" in hwconfig, (
+            "hardware-configuration.nix should reflect nixos-generate-config run on the target, "
+            "not the personal laptop"
+        )
+
+    with subtest("disk device/size prompts were written into the generated host config"):
+        hostnix = personal.succeed(
+            "cat /root/nixfiles-fixture/nixosConfigurations/test-host.nix"
+        )
+        print(f"test-host.nix:\n{hostnix}")
+        assert '"/dev/vdb"' in hostnix
+        assert '"512M"' in hostnix
+        assert '"1G"' in hostnix
+        assert "# encrypted.device" not in hostnix, (
+            "the disko block should no longer be a commented-out placeholder"
+        )
+
+    with subtest("the private ssh host key was delivered directly to target, not via a repo secret"):
+        target.succeed("test -f /tmp/ssh_host_ed25519_key")
+        perms = target.succeed("stat -c %a /tmp/ssh_host_ed25519_key").strip()
+        assert perms == "600", f"expected 0600, got {perms}"
+        target.fail(
+            "find /root -iname '*ssh-host-key*' | grep ."
+        )  # no passphrase-wrapped key secret should exist anywhere on target
+
+    # `target` only hosts the *bare* repo (standing in for GitHub) -- it has no working-copy
+    # clone of its own yet, so read fixture contents straight out of the bare repo via
+    # `git show`, exactly as `finish-remote-provision`'s own clone will see them.
+    with subtest("host-specific secrets are decryptable with the new host's own transferred key"):
+        for secret in ["luks-recovery-passphrase", "hashed-user-passphrase"]:
+            target.succeed(
+                f"git --git-dir=/srv/git/nixfiles.git show "
+                f"main:nixosConfigurations/test-host/secrets/{secret}.age "
+                f"| age -d -i /tmp/ssh_host_ed25519_key"
+            )
+
+    with subtest("rekey extended the shared github token secret to the new host"):
+        decrypted = target.succeed(
+            "git --git-dir=/srv/git/nixfiles.git show "
+            "main:nixosConfigurations/shared/secrets/github-access-token.age "
+            "| age -d -i /tmp/ssh_host_ed25519_key"
+        ).strip()
+        assert decrypted == "${fakeGithubTokenLine}", (
+            f"expected the fixture token line, got {decrypted!r} -- rekey should have added the "
+            "new host as a recipient during remote-provision"
+        )
+
+    with subtest("finish-remote-provision runs locally on target, no commit access needed"):
+        # finish-remote-provision does its own read-only clone of the (fixture) repo -- no
+        # separate `git clone` should be needed here. Run as "operator", a different user than
+        # remote-provision's ssh delivery used (root), to exercise the ownership handoff on
+        # /tmp/ssh_host_ed25519_key rather than trivially succeeding because both sides happen
+        # to be root.
+        log = target.succeed(
+            "su - operator -c "
+            "'(yes yes || true) | nixfiles finish-remote-provision test-host "
+            "--nixfiles-git-url=git://target/nixfiles.git --nixfiles-git-branch=main' "
+            "2>&1"
+        )
+        print(f"finish-remote-provision output:\n{log}")
+        # The disko stub itself fails loudly if /root/.config/nix/nix.conf doesn't already
+        # carry the github token when it runs -- finish-remote-provision succeeding above
+        # already proves that ordering requirement held.
+
+    with subtest("nix.conf got the token line verbatim, not re-wrapped in another prefix"):
+        nix_conf = target.succeed("cat /root/.config/nix/nix.conf")
+        print(f"/root/.config/nix/nix.conf:\n{nix_conf}")
+        assert nix_conf.strip() == "${fakeGithubTokenLine}", (
+            f"expected exactly the decrypted line, got {nix_conf!r} -- finish-remote-provision "
+            "must write the secret's content as-is, not wrap it in another access-tokens prefix"
+        )
+
+    with subtest("stubbed disko and nixos-install were invoked with the right flake/hostname"):
+        calls = target.succeed("cat /tmp/stub-calls.log")
+        print(f"stub calls:\n{calls}")
+        assert "disko" in calls and "test-host" in calls
+        assert "nixos-install" in calls and "--no-root-password" in calls
+        assert calls.index("disko") < calls.index("nixos-install"), (
+            "disko must run before nixos-install"
+        )
+
+    # `provision` is the original, still-maintained console/Yubikey flow: unlike remote-provision,
+    # it runs entirely on one machine and bootstraps its own git/GPG signing setup. Pre-seed an
+    # already-existing checkout (rather than letting it clone fresh) so that bootstrap is skipped
+    # and `commit.gpgsign` never gets enabled -- gpg/ssh-add are stubbed for the parts that do run
+    # (the "is a key already loaded" checks), so no real Yubikey is needed.
+    with subtest("seed a pre-existing checkout for provision (skips its clone+gpgsign setup)"):
+        standalone.succeed("git init --bare /root/origin.git")
+        standalone.succeed(
+            "git init -b main /root/nixfiles-standalone && "
+            "git -C /root/nixfiles-standalone config user.name test && "
+            "git -C /root/nixfiles-standalone config user.email test@example.com && "
+            "mkdir -p /root/nixfiles-standalone/nixosConfigurations/shared/secrets"
+        )
+        standalone.copy_from_host(
+            "${bootstrapNixFile}", "/root/nixfiles-standalone/nixosConfigurations/bootstrap.nix"
+        )
+        standalone.copy_from_host(
+            "${testAgeKey}/recipient.txt", "/root/nixfiles-standalone/master-recipients.txt"
+        )
+        standalone.copy_from_host("${testAgeKey}/identity.txt", "/root/master-identity.txt")
+        standalone.succeed(
+            "git -C /root/nixfiles-standalone add . && "
+            "git -C /root/nixfiles-standalone commit -m 'seed fixture' && "
+            "git -C /root/nixfiles-standalone remote add origin /root/origin.git && "
+            "git -C /root/nixfiles-standalone push origin HEAD:main && "
+            "git -C /root/nixfiles-standalone branch --set-upstream-to=origin/main main"
+        )
+
+    with subtest("provision runs entirely on one machine, no personal laptop needed"):
+        log = standalone.succeed(
+            "(yes yes || true) | nixfiles provision provision-host "
+            "--nixfiles-path=/root/nixfiles-standalone --nixfiles-git-branch=main "
+            "--age-identity=/root/master-identity.txt "
+            "2>&1"
+        )
+        print(f"provision output:\n{log}")
+
+    with subtest("provision generated its own hardware-configuration.nix locally"):
+        hwconfig = standalone.succeed(
+            "cat /root/nixfiles-standalone/nixosConfigurations/provision-host/hardware-configuration.nix"
+        )
+        print(f"hardware-configuration.nix:\n{hwconfig}")
+        assert "virtio_blk" in hwconfig
+
+    with subtest("provision's host config has the right hostname substituted"):
+        hostnix = standalone.succeed(
+            "cat /root/nixfiles-standalone/nixosConfigurations/provision-host.nix"
+        )
+        print(f"provision-host.nix:\n{hostnix}")
+        assert 'networking.hostName = "provision-host"' in hostnix
+        assert "./provision-host/hardware-configuration.nix" in hostnix
+
+    with subtest("provision generated its own ssh host key after mounting persistent"):
+        standalone.succeed("test -f /mnt/persistent/etc/ssh/ssh_host_ed25519_key")
+        standalone.succeed(
+            "test -f /root/nixfiles-standalone/nixosConfigurations/provision-host/ssh_host_ed25519_key.pub"
+        )
+
+    with subtest("provision's secrets are decryptable with its own just-generated host key"):
+        for secret in ["luks-recovery-passphrase", "hashed-user-passphrase"]:
+            standalone.succeed(
+                f"age -d -i /mnt/persistent/etc/ssh/ssh_host_ed25519_key "
+                f"/root/nixfiles-standalone/nixosConfigurations/provision-host/secrets/{secret}.age"
+            )
+
+    with subtest("provision committed and pushed to its origin"):
+        log = standalone.succeed("git --git-dir=/root/origin.git log --oneline main")
+        print(f"origin log:\n{log}")
+        assert "Provision provision-host" in log
+
+    with subtest("provision's stubbed disko and nixos-install were invoked correctly"):
+        calls = standalone.succeed("cat /tmp/stub-calls.log")
+        print(f"stub calls:\n{calls}")
+        assert "disko" in calls and "provision-host" in calls
+        assert "nixos-install" in calls and "--no-root-password" in calls
+        assert calls.index("disko") < calls.index("nixos-install"), (
+            "disko must run before nixos-install"
+        )
+  '';
+}


### PR DESCRIPTION
## Summary
- Adds `remote-provision` (run from an already-configured personal laptop, over SSH) and `finish-remote-provision` (run on the target's own console via the new `bin/finish-remote-provision.bash` launcher) so a work laptop can be provisioned without ever putting git commit access or a GPG signing key on it. `provision()` is untouched as the Yubikey/console fallback, now sharing disko/FIDO2/install helpers with the new commands.
- Adds `tests/nixfiles.nix`, a multi-node VM test covering all three flows with stubbed disko/FIDO2, including a non-root console user to catch an SSH host-key ownership handoff bug.
- Fixes several bugs found in review: `finish-remote-provision` crashing on an unbound `master_recipients` if it ever needs to generate a secret; `ensure-secret`'s prompt mode encrypting an empty value before validating it; `bin/finish-remote-provision.bash` missing `set -euo pipefail`.
- Consolidates the AWS-OIDC-to-nix-daemon credential wiring (previously copy-pasted across all three GitHub Actions workflows) into two composite actions, and gates the mid-job credential refresh in `build-and-push.yml` to the aarch64 leg, since the x86_64 hosts build well within the default STS session.
- Extracts more shared helpers in `packages/nixfiles.bash` (`init-host-config-file`, `ensure-hardware-config`, `ensure-hashed-user-passphrase`, `ensure-luks-recovery-passphrase-file`) to remove duplication between `provision()` and the new commands, and applies the existing `builtins.path` closure fix (previously only applied to `bashlib.bash`) to `packages/dictation.nix` and `nixosModules/mako.nix`, which had the same latent bug.
- `nixosConfigurations/hydor.nix`: gives hydor its own github access token, needed for manual builds and updating the private `kryptonix` flake input.