### PR TITLE
Evaluate configuration during remote provisioning

### DIFF
--- a/nixosConfigurations/hydor.nix
+++ b/nixosConfigurations/hydor.nix
@@ -9,17 +9,15 @@
           ./hydor/hardware-configuration.nix
         ];
         networking.hostName = "hydor";
-        services = {
-          syncthing = {
-            settings.folders = {
-              archive.enable = true;
-              obsidian.enable = true;
-              obsidian-work.enable = true;
-              org.enable = true;
-              org-work.enable = true;
-            };
-            thoughtfull.passwordFile = ./hydor/secrets/syncthing-passphrase.age;
+        services.syncthing = {
+          settings.folders = {
+            archive.enable = true;
+            obsidian.enable = true;
+            obsidian-work.enable = true;
+            org.enable = true;
+            org-work.enable = true;
           };
+          thoughtfull.passwordFile = ./hydor/secrets/syncthing-passphrase.age;
         };
         system.stateVersion = "25.11";
         thoughtfull = {

--- a/packages/nixfiles.bash
+++ b/packages/nixfiles.bash
@@ -283,6 +283,12 @@ remote-provision() {
   rekey "${argc_hostname}" ||
     die "Failed to rekey secrets"
 
+  log "Evaluating NixOS configuration"
+  nix eval --raw --no-write-lock-file \
+    "path:${argc_nixfiles_path}#nixosConfigurations.${argc_hostname}.config.system.build.toplevel.drvPath" \
+    >/dev/null ||
+    die "Failed to evaluate NixOS configuration: ${argc_hostname}"
+
   commit-and-push
 
   # == Print the exact command to finish provisioning on the target's own console

--- a/packages/nixfiles.bash
+++ b/packages/nixfiles.bash
@@ -278,6 +278,9 @@ remote-provision() {
     ensure-secret "${extra_secret}" prompt
   done
 
+  git add -- "${host_path}.nix" "${host_path}" ||
+    die "Failed to stage generated host configuration"
+
   # == Extend shared secrets (e.g. the github access token) to include the new host
   log "Rekeying shared secrets for the new host"
   rekey "${argc_hostname}" ||
@@ -285,7 +288,7 @@ remote-provision() {
 
   log "Evaluating NixOS configuration"
   nix eval --raw --no-write-lock-file \
-    "path:${argc_nixfiles_path}#nixosConfigurations.${argc_hostname}.config.system.build.toplevel.drvPath" \
+    "${argc_nixfiles_path}#nixosConfigurations.${argc_hostname}.config.system.build.toplevel.drvPath" \
     >/dev/null ||
     die "Failed to evaluate NixOS configuration: ${argc_hostname}"
 

--- a/tests/nixfiles.nix
+++ b/tests/nixfiles.nix
@@ -154,7 +154,12 @@ let
 
   stubNix = lib.hiPrio (
     pkgs.writeShellScriptBin "nix" ''
+      set -euo pipefail
       echo "nix $*" >>/tmp/stub-calls.log
+      git -C /root/nixfiles-fixture diff --cached --name-only |
+        grep -Fx nixosConfigurations/test-host.nix
+      git -C /root/nixfiles-fixture diff --cached --name-only |
+        grep -Fx nixosConfigurations/test-host/hardware-configuration.nix
       echo /nix/store/test-host-system.drv
     ''
   );
@@ -297,7 +302,7 @@ pkgs.testers.nixosTest {
     with subtest("remote-provision evaluates the generated host configuration"):
         personal.succeed(
             "grep -Fx 'nix eval --raw --no-write-lock-file "
-            "path:/root/nixfiles-fixture#nixosConfigurations.test-host.config.system.build.toplevel.drvPath' "
+            "/root/nixfiles-fixture#nixosConfigurations.test-host.config.system.build.toplevel.drvPath' "
             "/tmp/stub-calls.log"
         )
 

--- a/tests/nixfiles.nix
+++ b/tests/nixfiles.nix
@@ -151,6 +151,13 @@ let
       echo "/dev/vdb2"
     ''
   );
+
+  stubNix = lib.hiPrio (
+    pkgs.writeShellScriptBin "nix" ''
+      echo "nix $*" >>/tmp/stub-calls.log
+      echo /nix/store/test-host-system.drv
+    ''
+  );
 in
 pkgs.testers.nixosTest {
   name = "nixfiles";
@@ -167,6 +174,7 @@ pkgs.testers.nixosTest {
         environment.systemPackages = [
           testNixfiles
           pkgs.git
+          stubNix
           pkgs.whois # mkpasswd, used by ensure-secret for the hashed user passphrase
         ];
         services.openssh.enable = true;
@@ -285,6 +293,13 @@ pkgs.testers.nixosTest {
             "2>&1"
         )
         print(f"remote-provision output:\n{log}")
+
+    with subtest("remote-provision evaluates the generated host configuration"):
+        personal.succeed(
+            "grep -Fx 'nix eval --raw --no-write-lock-file "
+            "path:/root/nixfiles-fixture#nixosConfigurations.test-host.config.system.build.toplevel.drvPath' "
+            "/tmp/stub-calls.log"
+        )
 
     with subtest("a real (stubbed) hardware-configuration.nix was generated over ssh, not locally"):
         hwconfig = personal.succeed(


### PR DESCRIPTION
## Summary

- evaluate the generated NixOS configuration before remote provisioning commits and pushes it
- include generated, uncommitted host files by evaluating through a `path:` flake reference
- add VM coverage for the evaluation invocation
- simplify the Syncthing configuration indentation for Hydor