### PR TITLE
Generate Syncthing passphrase during provisioning

### DIFF
--- a/nixosConfigurations/bootstrap.nix
+++ b/nixosConfigurations/bootstrap.nix
@@ -8,6 +8,7 @@
           ./BOOTSTRAP/hardware-configuration.nix
         ];
         networking.hostName = "BOOTSTRAP";
+        services.syncthing.thoughtfull.passwordFile = ./BOOTSTRAP/secrets/syncthing-passphrase.age;
         system.stateVersion = "25.11";
         thoughtfull = {
           dev.enable = true;

--- a/packages/nixfiles.bash
+++ b/packages/nixfiles.bash
@@ -145,6 +145,8 @@ provision() {
   # == Ensure passphrases
   ensure-luks-recovery-passphrase-file
   ensure-hashed-user-passphrase
+  ensure-secret "Syncthing passphrase"
+  unset syncthing_passphrase
   # == Ensure partitions
   log "Ensure partitions"
   ensure-partitions
@@ -270,6 +272,8 @@ remote-provision() {
   ensure-secret "LUKS recovery passphrase"
   unset luks_recovery_passphrase
   ensure-hashed-user-passphrase
+  ensure-secret "Syncthing passphrase"
+  unset syncthing_passphrase
 
   git add -- "${host_path}.nix" "${host_path}" ||
     die "Failed to stage generated host configuration"

--- a/packages/nixfiles.bash
+++ b/packages/nixfiles.bash
@@ -202,9 +202,6 @@ provision() {
 ##
 ## @option --swap-size $$
 ## size of the swap file -- prompted for if unset
-##
-## @option --extra-secret* $$
-## additional secret name(s) to prompt for and encrypt now (e.g. an aws-secret-key)
 remote-provision() {
   argc_age_identity=${argc_age_identity:-${argc_nixfiles_path}/master-identities.txt}
   master_recipients="${argc_nixfiles_path}/master-recipients.txt"
@@ -273,10 +270,6 @@ remote-provision() {
   ensure-secret "LUKS recovery passphrase"
   unset luks_recovery_passphrase
   ensure-hashed-user-passphrase
-  for extra_secret in "${argc_extra_secret[@]:-}"; do
-    [[ -n ${extra_secret} ]] || continue
-    ensure-secret "${extra_secret}" prompt
-  done
 
   git add -- "${host_path}.nix" "${host_path}" ||
     die "Failed to stage generated host configuration"

--- a/tests/nixfiles.nix
+++ b/tests/nixfiles.nix
@@ -320,6 +320,7 @@ pkgs.testers.nixosTest {
         hostnix = personal.succeed(
             "cat /root/nixfiles-fixture/nixosConfigurations/test-host.nix"
         )
+        normalized_hostnix = " ".join(hostnix.split())
         print(f"test-host.nix:\n{hostnix}")
         assert '"/dev/vdb"' in hostnix
         assert '"512M"' in hostnix
@@ -327,6 +328,10 @@ pkgs.testers.nixosTest {
         assert "# encrypted.device" not in hostnix, (
             "the disko block should no longer be a commented-out placeholder"
         )
+        assert (
+            "services.syncthing.thoughtfull.passwordFile = "
+            "./test-host/secrets/syncthing-passphrase.age;"
+        ) in normalized_hostnix
 
     with subtest("the private ssh host key was delivered directly to target, not via a repo secret"):
         target.succeed("test -f /tmp/ssh_host_ed25519_key")
@@ -340,7 +345,11 @@ pkgs.testers.nixosTest {
     # clone of its own yet, so read fixture contents straight out of the bare repo via
     # `git show`, exactly as `finish-remote-provision`'s own clone will see them.
     with subtest("host-specific secrets are decryptable with the new host's own transferred key"):
-        for secret in ["luks-recovery-passphrase", "hashed-user-passphrase"]:
+        for secret in [
+            "luks-recovery-passphrase",
+            "hashed-user-passphrase",
+            "syncthing-passphrase",
+        ]:
             target.succeed(
                 f"git --git-dir=/srv/git/nixfiles.git show "
                 f"main:nixosConfigurations/test-host/secrets/{secret}.age "
@@ -440,9 +449,14 @@ pkgs.testers.nixosTest {
         hostnix = standalone.succeed(
             "cat /root/nixfiles-standalone/nixosConfigurations/provision-host.nix"
         )
+        normalized_hostnix = " ".join(hostnix.split())
         print(f"provision-host.nix:\n{hostnix}")
         assert 'networking.hostName = "provision-host"' in hostnix
         assert "./provision-host/hardware-configuration.nix" in hostnix
+        assert (
+            "services.syncthing.thoughtfull.passwordFile = "
+            "./provision-host/secrets/syncthing-passphrase.age;"
+        ) in normalized_hostnix
 
     with subtest("provision generated its own ssh host key after mounting persistent"):
         standalone.succeed("test -f /mnt/persistent/etc/ssh/ssh_host_ed25519_key")
@@ -451,7 +465,11 @@ pkgs.testers.nixosTest {
         )
 
     with subtest("provision's secrets are decryptable with its own just-generated host key"):
-        for secret in ["luks-recovery-passphrase", "hashed-user-passphrase"]:
+        for secret in [
+            "luks-recovery-passphrase",
+            "hashed-user-passphrase",
+            "syncthing-passphrase",
+        ]:
             standalone.succeed(
                 f"age -d -i /mnt/persistent/etc/ssh/ssh_host_ed25519_key "
                 f"/root/nixfiles-standalone/nixosConfigurations/provision-host/secrets/{secret}.age"


### PR DESCRIPTION
## Summary

- generate an encrypted Syncthing GUI passphrase during local and remote provisioning
- configure bootstrap hosts to use the generated passphrase
- cover both provisioning paths in the NixOS VM test
- remove the unused remote provisioning extra-secret option

Closes #200