### PR TITLE
Allow github token access

### DIFF
--- a/nixosModules/github-token.nix
+++ b/nixosModules/github-token.nix
@@ -20,7 +20,10 @@ let
 in
 {
   config = mkIf (githubToken.tokenFile != null) {
-    age.secrets.github-access-token.file = githubToken.tokenFile;
+    age.secrets.github-access-token = {
+      mode = "0644";
+      file = githubToken.tokenFile;
+    };
     nix.extraOptions = ''
       !include ${config.age.secrets.github-access-token.path}
     '';


### PR DESCRIPTION
If someone is already on my machine they can inspect my username, network, nix store, etc. so it's not really worth hiding the github token (which is read only).