### PR TITLE
Persist opencode data

### DIFF
--- a/nixosModules/dev.nix
+++ b/nixosModules/dev.nix
@@ -34,7 +34,12 @@ in
         ".config/gh"
       ]
       ++ (optionals claude.enable [ ".claude" ])
-      ++ (optionals opencode.enable [ ".config/opencode" ]);
+      ++ (optionals opencode.enable [
+        ".cache/opencode"
+        ".config/opencode"
+        ".local/share/opencode"
+        ".local/state/opencode"
+      ]);
       files = optionals claude.enable [ ".claude.json" ];
     };
   };

--- a/tests/dev.nix
+++ b/tests/dev.nix
@@ -31,16 +31,31 @@ extendedNixpkgs.testers.nixosTest {
   skipLint = true;
 
   nodes = {
-    enabled = {
-      imports = [
-        ../nixosModules/dev.nix
-        thoughtfullSubModuleStub
-      ];
-      thoughtfull.dev.enable = true;
-      # nixosModules/java.nix sets programs.java.enable = mkDefault true in the
-      # full system; mirror that here so the package selection is exercised.
-      programs.java.enable = true;
-    };
+    enabled =
+      { config, ... }:
+      {
+        imports = [
+          ../nixosModules/dev.nix
+          thoughtfullSubModuleStub
+        ];
+        thoughtfull.dev.enable = true;
+        # nixosModules/java.nix sets programs.java.enable = mkDefault true in the
+        # full system; mirror that here so the package selection is exercised.
+        programs.java.enable = true;
+        assertions =
+          let
+            opencodeDirectories = [
+              ".cache/opencode"
+              ".config/opencode"
+              ".local/share/opencode"
+              ".local/state/opencode"
+            ];
+          in
+          map (directory: {
+            assertion = builtins.elem directory config.thoughtfull.impermanence.user.directories;
+            message = "expected opencode persistence directory ${directory}";
+          }) opencodeDirectories;
+      };
 
     disabled = {
       imports = [

--- a/tests/dev.nix
+++ b/tests/dev.nix
@@ -4,6 +4,13 @@ let
   # ignored with external pkgs, so apply the overlay here (see tests/default.nix).
   extendedNixpkgs = nixpkgs.extend self.inputs.llm-agents.overlays.default;
 
+  opencodeDirectories = [
+    ".cache/opencode"
+    ".config/opencode"
+    ".local/share/opencode"
+    ".local/state/opencode"
+  ];
+
   # Stub the thoughtfull sub-module options that dev.nix sets via mkDefault
   thoughtfullSubModuleStub =
     { lib, ... }:
@@ -42,19 +49,28 @@ extendedNixpkgs.testers.nixosTest {
         # nixosModules/java.nix sets programs.java.enable = mkDefault true in the
         # full system; mirror that here so the package selection is exercised.
         programs.java.enable = true;
-        assertions =
-          let
-            opencodeDirectories = [
-              ".cache/opencode"
-              ".config/opencode"
-              ".local/share/opencode"
-              ".local/state/opencode"
-            ];
-          in
-          map (directory: {
-            assertion = builtins.elem directory config.thoughtfull.impermanence.user.directories;
-            message = "expected opencode persistence directory ${directory}";
-          }) opencodeDirectories;
+        assertions = map (directory: {
+          assertion = builtins.elem directory config.thoughtfull.impermanence.user.directories;
+          message = "expected opencode persistence directory ${directory}";
+        }) opencodeDirectories;
+      };
+
+    opencodeDisabled =
+      { config, ... }:
+      {
+        imports = [
+          ../nixosModules/dev.nix
+          thoughtfullSubModuleStub
+        ];
+        thoughtfull.dev = {
+          enable = true;
+          agents.opencode.enable = false;
+        };
+        programs.java.enable = true;
+        assertions = map (directory: {
+          assertion = !(builtins.elem directory config.thoughtfull.impermanence.user.directories);
+          message = "unexpected opencode persistence directory ${directory}";
+        }) opencodeDirectories;
       };
 
     disabled = {
@@ -68,6 +84,7 @@ extendedNixpkgs.testers.nixosTest {
   testScript = ''
     start_all()
     enabled.wait_for_unit("multi-user.target")
+    opencodeDisabled.wait_for_unit("multi-user.target")
     disabled.wait_for_unit("multi-user.target")
 
     with subtest("enabled: devenv is in PATH"):
@@ -83,6 +100,9 @@ extendedNixpkgs.testers.nixosTest {
 
     with subtest("enabled default: opencode is in PATH"):
         enabled.succeed("which opencode")
+
+    with subtest("opencode disabled: opencode is not available"):
+        opencodeDisabled.fail("which opencode")
 
     with subtest("disabled default: devenv is not available"):
         disabled.fail("which devenv")


### PR DESCRIPTION
## Summary
- Persist opencode cache, data, and state directories when opencode is enabled.
- Assert the opencode persistence directories are present by default and absent when opencode is disabled.

## Verification
- nix build .#checks.x86_64-linux.dev
- devenv tasks run devenv:git-hooks:run