### PR TITLE
Add ntfy-test helper and alert-on-failure-test self-test service

### DIFF
--- a/nixosModules/monitoring.nix
+++ b/nixosModules/monitoring.nix
@@ -11,23 +11,37 @@ let
     mkOption
     types
     ;
-  inherit (pkgs) curl;
+  inherit (pkgs) ntfy-sh;
   inherit (pkgs.thoughtfull) writeFileScriptBin;
   cfg = config.thoughtfull.monitoring;
 
   alert-script = writeFileScriptBin {
     name = "ntfy";
     replacements = {
-      curl = "${curl}/bin/curl";
+      ntfy = "${ntfy-sh}/bin/ntfy";
       systemctl = "${pkgs.systemd}/bin/systemctl";
       ntfyServer = cfg.ntfyServer;
       ntfyTopic = cfg.ntfyTopic;
     };
     src = ./monitoring/ntfy.bash;
   };
+
+  ntfy-test-script = writeFileScriptBin {
+    name = "ntfy-test";
+    replacements = {
+      ntfyServer = cfg.ntfyServer;
+      ntfyTopic = cfg.ntfyTopic;
+    };
+    src = ./monitoring/ntfy-test.bash;
+  };
 in
 {
   config = mkIf cfg.enable {
+    environment.systemPackages = [
+      ntfy-sh
+      ntfy-test-script
+    ];
+
     systemd.services = {
       "alert-on-failure@" = {
         description = "Send alert for failed unit %i";
@@ -39,6 +53,15 @@ in
         serviceConfig = {
           Type = "oneshot";
           ExecStart = "${alert-script}/bin/ntfy";
+        };
+      };
+
+      alert-on-failure-test = {
+        description = "Test service that fails on purpose to exercise alert-on-failure";
+        onFailure = [ "alert-on-failure@%n.service" ];
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = "${pkgs.coreutils}/bin/false";
         };
       };
     }

--- a/nixosModules/monitoring/ntfy-test.bash
+++ b/nixosModules/monitoring/ntfy-test.bash
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MESSAGE="${1:-This is only a test}"
+
+ntfy publish --title "Test message" --tags rotating_light "@ntfyServer@/@ntfyTopic@" "${MESSAGE}"

--- a/nixosModules/monitoring/ntfy.bash
+++ b/nixosModules/monitoring/ntfy.bash
@@ -10,10 +10,10 @@ MESSAGE="${DESCRIPTION} failed on ${HOST}
 $(SYSTEMD_COLORS=0 @systemctl@ --no-pager status "${UNIT}" 2>&1 || true)
 \`\`\`"
 
-@curl@ \
-  -H "Title: ${DESCRIPTION} failed" \
-  -H "Priority: high" \
-  -H "Tags: x" \
-  -H "Markdown: yes" \
-  -d "${MESSAGE}" \
-  @ntfyServer@/@ntfyTopic@
+@ntfy@ publish \
+  --title "${DESCRIPTION} failed" \
+  --priority high \
+  --tags x \
+  --markdown \
+  "@ntfyServer@/@ntfyTopic@" \
+  "${MESSAGE}"

--- a/tests.nix
+++ b/tests.nix
@@ -19,6 +19,7 @@ forEachSystem (
     dev = callTest ./tests/dev.nix;
     github-token = callTest ./tests/github-token.nix;
     graphical = callTest ./tests/graphical.nix;
+    monitoring = callTest ./tests/monitoring.nix;
     nixfiles = callTest ./tests/nixfiles.nix;
     system-pull = callTest ./tests/system-pull.nix;
     waybar = callTest ./tests/waybar.nix;

--- a/tests/monitoring.nix
+++ b/tests/monitoring.nix
@@ -1,0 +1,72 @@
+{ nixpkgs, self, ... }:
+let
+  # Apply the thoughtfull overlay so pkgs.thoughtfull.writeFileScriptBin resolves.
+  overlayModule = {
+    nixpkgs.overlays = [ self.overlays.thoughtfull ];
+  };
+
+  imports = [
+    ../nixosModules/monitoring.nix
+    overlayModule
+  ];
+in
+nixpkgs.testers.nixosTest {
+  name = "monitoring";
+
+  skipTypeCheck = true;
+  skipLint = true;
+
+  nodes = {
+    machine =
+      { pkgs, ... }:
+      {
+        inherit imports;
+        thoughtfull.monitoring = {
+          enable = true;
+          ntfyServer = "http://127.0.0.1:8000";
+          ntfyTopic = "test-topic";
+        };
+        # Test-only: a mock ntfy server to capture what the module sends,
+        # since the test VM has no real network access.
+        environment.systemPackages = [ pkgs.python3 ];
+        environment.etc."mock-ntfy.py".source = ./monitoring/mock-ntfy.py;
+      };
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("ntfy and ntfy-test are on PATH"):
+        machine.succeed("which ntfy")
+        machine.succeed("which ntfy-test")
+
+    with subtest("start the mock ntfy server"):
+        machine.succeed("systemd-run --unit=mock-ntfy --collect python3 /etc/mock-ntfy.py")
+        machine.wait_for_open_port(8000)
+
+    with subtest("ntfy-test with no arguments sends the default test message"):
+        machine.succeed("ntfy-test")
+        log = machine.succeed("cat /tmp/requests.log")
+        print(f"requests log:\n{log}")
+        assert "/test-topic" in log, "should post to the configured topic"
+        assert "This is only a test" in log, "default message should be sent"
+        assert "title=Test message" in log, "should set the title"
+        assert "tags=rotating_light" in log, "should tag the message with a red alert light"
+
+    with subtest("ntfy-test with an argument sends that argument"):
+        machine.succeed("rm -f /tmp/requests.log")
+        machine.succeed("ntfy-test 'custom alert body'")
+        log = machine.succeed("cat /tmp/requests.log")
+        print(f"requests log:\n{log}")
+        assert "custom alert body" in log, "argument should be sent as the message"
+
+    with subtest("alert-on-failure-test.service fails on purpose and triggers alert-on-failure"):
+        machine.succeed("rm -f /tmp/requests.log")
+        machine.fail("systemctl start alert-on-failure-test.service")
+        machine.wait_until_succeeds("test -s /tmp/requests.log")
+        log = machine.succeed("cat /tmp/requests.log")
+        print(f"requests log:\n{log}")
+        assert "alert-on-failure-test" in log, "alert-on-failure should report the failed unit"
+  '';
+}

--- a/tests/monitoring/mock-ntfy.py
+++ b/tests/monitoring/mock-ntfy.py
@@ -1,0 +1,34 @@
+import http.server
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+        title = self.headers.get("X-Title", "")
+        tags = self.headers.get("X-Tags", "")
+        with open("/tmp/requests.log", "ab") as f:
+            f.write(
+                self.path.encode()
+                + b"\ntitle="
+                + title.encode()
+                + b"\ntags="
+                + tags.encode()
+                + b"\n"
+                + body
+                + b"\n---\n"
+            )
+        # The ntfy client JSON-decodes the response body as a publish ack,
+        # so an empty body makes it fail with an "EOF" decode error.
+        response = b'{"id":"test","time":0,"event":"message","topic":"test-topic"}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(response)
+
+    def log_message(self, format, *args):
+        pass
+
+
+http.server.HTTPServer(("127.0.0.1", 8000), Handler).serve_forever()


### PR DESCRIPTION
## Summary
- Adds an `ntfy-test` script (installed on PATH) that publishes a manual test message to the configured ntfy topic — no args sends "This is only a test", an argument sends that message instead.
- Adds an `alert-on-failure-test` systemd oneshot service that fails on purpose so operators can manually exercise the existing `alert-on-failure@` alerting pipeline via `systemctl start alert-on-failure-test.service`.
- Switches the production alert script (`ntfy.bash`, used by `alert-on-failure@`) from raw `curl` to the `ntfy` CLI, so both the production and manual-test paths publish through the same client instead of two independently-formatted HTTP requests.
- Adds a NixOS VM test (`tests/monitoring.nix`) covering all of the above against a mock ntfy HTTP server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)