### PR TITLE
Install man pages for argc scripts

### DIFF
--- a/overlays/thoughtfull.nix
+++ b/overlays/thoughtfull.nix
@@ -70,12 +70,16 @@ let
         bashlib = bashlib;
       };
       outFile = "$out/bin/${name}";
+      manDir = "$out/share/man/man1";
     in
     runCommandLocal name { } ''
       mkdir -p $(dirname "${outFile}")
       cat "${prefix}" >"${name}"
       cat "${replaceVars src replacements}" >>"${name}"
       ${argc}/bin/argc --argc-build "${name}" "${outFile}"
+
+      mkdir -p "${manDir}"
+      ${argc}/bin/argc --argc-mangen "${name}" "${manDir}"
     '';
 in
 {
@@ -91,7 +95,6 @@ in
 
     # Custom packages (keep alphabetized)
     attach-yubikey = writeArgcScript "attach-yubikey" ../packages/attach-yubikey.bash {
-      bash = "${bash}/bin/bash";
       nc = "${netcat}/bin/nc";
     };
     brightness = import ../packages/brightness.nix {


### PR DESCRIPTION
## Summary
- `writeArgcScript` now runs `argc --argc-mangen` and installs the generated man page(s) into `$out/share/man/man1`, alongside the built binary. This covers all four argc-based packages: `attach-yubikey`, `detach-yubikey`, `nixfiles` (one page per subcommand), and `run-vm`.
- Fixes a pre-existing build failure in `attach-yubikey`: its replacement set passed an unused `bash` key not referenced anywhere in the script, which the pinned nixpkgs' `replaceVars` rejects as a strict unused-key error.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)