### PR TITLE
Generate and wire up zsh completions for argc scripts

### DIFF
--- a/nixosModules/zsh.nix
+++ b/nixosModules/zsh.nix
@@ -9,7 +9,13 @@ let
   inherit (lib) mkDefault mkIf;
 in
 {
-  environment.systemPackages = mkIf zsh.enable [ pkgs.tldr ];
+  environment.systemPackages = mkIf zsh.enable [
+    pkgs.tldr
+    # Needed at completion time by scripts built with `writeArgcScript`: their sourced
+    # `share/zsh/argc-completions/*` files shell out to `argc --argc-compgen` to compute
+    # candidates.
+    pkgs.argc
+  ];
   programs.zsh = {
     autosuggestions.enable = mkDefault true;
     histFile = "$HOME/.config/zsh/history";
@@ -25,6 +31,14 @@ in
       help() {
         { ${pkgs.tldr}/bin/tldr "$@" || man "$@" || "$@" --help || run-help "$@" } 2>/dev/null
       }
+
+      # Completions for scripts built with `writeArgcScript`. These must be sourced directly
+      # (after compinit, which has already run by this point) rather than relying on fpath
+      # autoloading -- see the comment on `zshCompletionsDir` in overlays/thoughtfull.nix.
+      for _argc_completion in /run/current-system/sw/share/zsh/argc-completions/*(N); do
+        source "$_argc_completion"
+      done
+      unset _argc_completion
     '';
     # zprofile
     loginShellInit = "";

--- a/overlays/thoughtfull.nix
+++ b/overlays/thoughtfull.nix
@@ -71,6 +71,12 @@ let
       };
       outFile = "$out/bin/${name}";
       manDir = "$out/share/man/man1";
+      # `/share/zsh` is already in `environment.pathsToLink`'s default, so files placed here get
+      # merged into the system profile with no further NixOS config needed. Not named `_${name}`
+      # / placed under `site-functions`: argc's generated completer isn't a normal
+      # fpath-autoloadable completion function (it has no `#compdef` tag and calls `compdef`
+      # itself), so it must be `source`d directly by absolute path rather than autoloaded.
+      zshCompletionsDir = "$out/share/zsh/argc-completions";
     in
     runCommandLocal name { } ''
       mkdir -p $(dirname "${outFile}")
@@ -80,6 +86,9 @@ let
 
       mkdir -p "${manDir}"
       ${argc}/bin/argc --argc-mangen "${name}" "${manDir}"
+
+      mkdir -p "${zshCompletionsDir}"
+      ${argc}/bin/argc --argc-completions zsh "${name}" >"${zshCompletionsDir}/${name}"
     '';
 in
 {


### PR DESCRIPTION
## Summary
- `writeArgcScript` now also runs `argc --argc-completions zsh` and installs the result under `share/zsh/argc-completions`, alongside the existing binary and man pages.
- `zsh.nix` sources these files directly from `interactiveShellInit` (after compinit has run) and adds `argc` to `systemPackages`, since the generated completer shells out to `argc --argc-compgen` at completion time.

argc's zsh completion output isn't a normal fpath-autoloadable `_name` file (no `#compdef` tag, and it calls `compdef` itself), so it has to be `source`d directly rather than dropped into `site-functions`. `/share/zsh` is already in `environment.pathsToLink`'s default, so no extra NixOS plumbing was needed to get the completions directory into the merged system profile.

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)