### PR TITLE
Add display management to Waybar via kanshi

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,7 @@
             theme-toggle
             uns
             usb-menu
+            waybar-displays
             waybar-weather
             waybar-yubikey
             yubikey-totp

--- a/nixosModules/sway.nix
+++ b/nixosModules/sway.nix
@@ -68,6 +68,7 @@ in
   };
   imports = [
     ./sway/idle.nix
+    ./sway/kanshi.nix
     ./sway/notify.nix
     ./sway/waybar.nix
   ];

--- a/nixosModules/sway/kanshi.nix
+++ b/nixosModules/sway/kanshi.nix
@@ -1,0 +1,37 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (config.programs) sway;
+  inherit (lib) mkIf;
+  inherit (pkgs)
+    kanshi
+    wdisplays
+    ;
+  inherit (pkgs.thoughtfull) waybar-displays;
+in
+{
+  environment = mkIf sway.enable {
+    etc."xdg/kanshi/config".source = ./kanshi/config;
+    systemPackages = [
+      kanshi
+      wdisplays
+    ];
+  };
+  systemd.user.services.kanshi = mkIf sway.enable {
+    after = [ "sway-session.target" ];
+    bindsTo = [ "sway-session.target" ];
+    wantedBy = [ "sway-session.target" ];
+    # kanshi-active (invoked from profile `exec` directives) records the active
+    # profile and signals Waybar.
+    path = [ waybar-displays ];
+    serviceConfig = {
+      ExecStart = "${kanshi}/bin/kanshi --config /etc/xdg/kanshi/config";
+      Restart = "on-failure";
+      RestartSec = 1;
+    };
+  };
+}

--- a/nixosModules/sway/kanshi/config
+++ b/nixosModules/sway/kanshi/config
@@ -1,0 +1,18 @@
+# kanshi output profiles.
+#
+# Each profile calls `kanshi-active` so the Waybar displays widget shows the
+# right icon (laptop = undocked, monitor = docked), and the widget's right-click
+# toggles between the two. Run `swaymsg -t get_outputs` to inspect outputs; the
+# external monitor is matched by its `make model serial` identifier so it keeps
+# working across connector renumbering, the laptop panel by its stable eDP-1 name.
+
+profile docked {
+    output "ICB HDMI ICB UHD 60" enable mode 3840x2160@59.996Hz position 0,0 scale 1.3
+    output eDP-1 enable mode 1920x1200@59.999Hz position 2953,0 scale 1.0
+    exec kanshi-active docked
+}
+
+profile undocked {
+    output eDP-1 enable mode 1920x1200@59.999Hz position 0,0 scale 1.0
+    exec kanshi-active undocked
+}

--- a/nixosModules/sway/waybar.nix
+++ b/nixosModules/sway/waybar.nix
@@ -15,8 +15,9 @@ let
     networkmanagerapplet
     pasystray
     waybar
+    wdisplays
     ;
-  inherit (pkgs.thoughtfull) theme-toggle waybar-yubikey;
+  inherit (pkgs.thoughtfull) theme-toggle waybar-displays waybar-yubikey;
   power-menu = pkgs.thoughtfull.power-menu.override { gtklock = gtklock.package; };
   cfg = config.programs.waybar;
 in
@@ -81,7 +82,9 @@ in
         gtklock.package
         power-menu
         theme-toggle
+        waybar-displays
         waybar-yubikey
+        wdisplays
       ];
     };
   };

--- a/nixosModules/sway/waybar/config.jsonc
+++ b/nixosModules/sway/waybar/config.jsonc
@@ -6,7 +6,7 @@
 
   "modules-left": ["sway/workspaces", "sway/scratchpad" ],
   "modules-center": [],
-  "modules-right": ["sway/mode", "custom/yubikey", "custom/weather", "clock", "clock#utc", "battery", "tray", "custom/theme", "custom/lock", "custom/power"],
+  "modules-right": ["sway/mode", "custom/yubikey", "custom/weather", "clock", "clock#utc", "battery", "tray", "custom/displays", "custom/theme", "custom/lock", "custom/power"],
 
   "sway/workspaces": {
     "disable-scroll": false,
@@ -96,5 +96,15 @@
     "format": "<span font=\"20px\">󰐥</span>",
     "tooltip-format": "Power menu",
     "on-click": "power-menu --no-lock"
+  },
+
+  "custom/displays": {
+    "format": "<span font=\"20px\">{}</span>",
+    "exec": "waybar-displays",
+    "interval": 60,
+    "signal": 4,
+    "on-click": "wdisplays",
+    "on-click-right": "kanshi-toggle",
+    "tooltip-format": "Display settings"
   }
 }

--- a/nixosModules/sway/waybar/style.css
+++ b/nixosModules/sway/waybar/style.css
@@ -48,6 +48,7 @@ window#waybar {
 #clock,
 #custom-weather,
 #custom-yubikey,
+#custom-displays,
 #custom-theme,
 #custom-lock,
 #custom-power,
@@ -99,6 +100,7 @@ window#waybar {
   margin: 0 6pt 0 0;
 }
 
+#custom-displays:hover,
 #custom-theme:hover,
 #custom-lock:hover,
 #custom-power:hover {

--- a/overlays/thoughtfull.nix
+++ b/overlays/thoughtfull.nix
@@ -201,6 +201,12 @@ in
       };
       pkgs = final;
     };
+    waybar-displays = import ../packages/waybar-displays.nix {
+      lib = {
+        inherit writeFileScriptBin;
+      };
+      pkgs = final;
+    };
     waybar-weather = import ../packages/waybar-weather.nix {
       lib = {
         inherit writeFileScriptBin;

--- a/packages/waybar-displays.nix
+++ b/packages/waybar-displays.nix
@@ -1,0 +1,41 @@
+{ lib, pkgs, ... }:
+let
+  inherit (pkgs)
+    bash
+    kanshi
+    procps
+    symlinkJoin
+    ;
+  inherit (lib) writeFileScriptBin;
+  waybar-displays = writeFileScriptBin {
+    name = "waybar-displays";
+    replacements = {
+      bash = "${bash}/bin/bash";
+    };
+    src = ./waybar-displays/waybar-displays.bash;
+  };
+  kanshi-active = writeFileScriptBin {
+    name = "kanshi-active";
+    replacements = {
+      bash = "${bash}/bin/bash";
+      pkill = "${procps}/bin/pkill";
+    };
+    src = ./waybar-displays/kanshi-active.bash;
+  };
+  kanshi-toggle = writeFileScriptBin {
+    name = "kanshi-toggle";
+    replacements = {
+      bash = "${bash}/bin/bash";
+      kanshictl = "${kanshi}/bin/kanshictl";
+    };
+    src = ./waybar-displays/kanshi-toggle.bash;
+  };
+in
+symlinkJoin {
+  name = "waybar-displays";
+  paths = [
+    kanshi-active
+    kanshi-toggle
+    waybar-displays
+  ];
+}

--- a/packages/waybar-displays/kanshi-active.bash
+++ b/packages/waybar-displays/kanshi-active.bash
@@ -1,0 +1,13 @@
+#!@bash@
+set -euo pipefail
+
+# Record the kanshi profile that just became active so the Waybar displays
+# widget can pick the right icon, then poke Waybar to refresh it. kanshi runs
+# this from each profile's `exec` directive, e.g. `exec kanshi-active docked`.
+dir="${XDG_RUNTIME_DIR:-/run/user/$UID}/kanshi"
+mkdir -p "$dir"
+printf '%s\n' "${1:-}" >"$dir/active-profile"
+
+# Refresh custom/displays (signal 4). Ignore failure so switching profiles still
+# works when Waybar isn't running.
+@pkill@ -RTMIN+4 waybar || true

--- a/packages/waybar-displays/kanshi-toggle.bash
+++ b/packages/waybar-displays/kanshi-toggle.bash
@@ -1,0 +1,15 @@
+#!@bash@
+set -euo pipefail
+
+# Toggle between the docked and undocked kanshi profiles. Bound to the Waybar
+# displays widget's right-click. The active profile is recorded by kanshi-active
+# when kanshi applies a profile.
+file="${XDG_RUNTIME_DIR:-/run/user/$UID}/kanshi/active-profile"
+current="$(cat "$file" 2>/dev/null || true)"
+
+case "$current" in
+  docked) target=undocked ;;
+  *) target=docked ;;
+esac
+
+@kanshictl@ switch "$target"

--- a/packages/waybar-displays/waybar-displays.bash
+++ b/packages/waybar-displays/waybar-displays.bash
@@ -1,0 +1,14 @@
+#!@bash@
+set -euo pipefail
+
+# Print the Waybar icon for the active kanshi profile: a laptop when undocked, a
+# monitor when docked (or when the profile is unknown, e.g. before kanshi has
+# applied one). kanshi-active records the profile name and signals Waybar
+# (SIGRTMIN+4, see custom/displays "signal") to re-run this script.
+file="${XDG_RUNTIME_DIR:-/run/user/$UID}/kanshi/active-profile"
+profile="$(cat "$file" 2>/dev/null || true)"
+
+case "$profile" in
+  undocked) printf '%s\n' '󰌢' ;;
+  *) printf '%s\n' '󰍹' ;;
+esac

--- a/tests/waybar.nix
+++ b/tests/waybar.nix
@@ -7,7 +7,7 @@ nixpkgs.testers.nixosTest {
 
   nodes = {
     machine =
-      { lib, ... }:
+      { lib, pkgs, ... }:
       {
         imports = [
           # Import the sway/waybar module and its direct dependencies
@@ -31,6 +31,9 @@ nixpkgs.testers.nixosTest {
         programs.sway.enable = true;
         programs.waybar.enable = true;
         programs.yubikey-touch-detector.enable = true;
+
+        # Make the displays widget's scripts callable from the test script.
+        environment.systemPackages = [ pkgs.thoughtfull.waybar-displays ];
 
         # Create a test user for user services
         users.users.testuser = {
@@ -84,5 +87,54 @@ nixpkgs.testers.nixosTest {
         # Verify the service completed successfully
         machine.succeed("journalctl -u restart-yubikey-touch-detector.service --no-pager | grep -q 'Starting Restart YubiKey touch detector after resume'")
         machine.succeed("journalctl -u restart-yubikey-touch-detector.service --no-pager | grep -q 'Finished Restart YubiKey touch detector after resume'")
+
+    with subtest("waybar config wires up the displays widget"):
+        # The displays module is present and placed after the tray.
+        config = machine.succeed("cat /etc/xdg/waybar/config.jsonc")
+        assert '"custom/displays"' in config, "custom/displays module missing"
+        assert config.index('"tray"') < config.index('"custom/displays"'), (
+            "custom/displays should come after tray in modules-right"
+        )
+        # It refreshes on a signal and, as a signal-driven module, also has a
+        # polling interval so a missed signal self-heals.
+        machine.succeed("grep -q '\"exec\": \"waybar-displays\"' /etc/xdg/waybar/config.jsonc")
+        machine.succeed("grep -q '\"signal\": 4' /etc/xdg/waybar/config.jsonc")
+        machine.succeed("grep -q '\"interval\": 60' /etc/xdg/waybar/config.jsonc")
+
+    with subtest("waybar service PATH provides the widget's tooling"):
+        # on-click launches wdisplays; exec runs waybar-displays (which also
+        # bundles kanshi-toggle for on-click-right). NixOS renders the service
+        # `path` into a PATH= line in a drop-in override, not the main unit.
+        dropin = machine.succeed("cat /etc/systemd/user/waybar.service.d/*.conf")
+        assert "waybar-displays" in dropin, "waybar-displays missing from waybar PATH"
+        assert "wdisplays" in dropin, "wdisplays missing from waybar PATH"
+
+    with subtest("waybar-displays reflects the active kanshi profile"):
+        machine.succeed("mkdir -p /run/user/1000/kanshi")
+
+        def displays_icon():
+            return machine.succeed(
+                "XDG_RUNTIME_DIR=/run/user/1000 waybar-displays"
+            ).strip()
+
+        machine.succeed("echo undocked > /run/user/1000/kanshi/active-profile")
+        undocked = displays_icon()
+
+        machine.succeed("echo docked > /run/user/1000/kanshi/active-profile")
+        docked = displays_icon()
+
+        assert undocked != docked, (
+            f"docked and undocked should show different icons (got {undocked!r} / {docked!r})"
+        )
+
+        # An unknown/absent profile falls back to the docked (monitor) icon.
+        machine.succeed("rm -f /run/user/1000/kanshi/active-profile")
+        assert displays_icon() == docked, "missing profile should fall back to the docked icon"
+
+    with subtest("kanshi-active records the applied profile"):
+        # pkill of a non-running waybar is tolerated (|| true), so this still
+        # writes the state file that waybar-displays reads.
+        machine.succeed("XDG_RUNTIME_DIR=/run/user/1000 kanshi-active undocked")
+        machine.succeed("grep -qx undocked /run/user/1000/kanshi/active-profile")
   '';
 }


### PR DESCRIPTION
Add a Waybar "displays" widget for managing monitor configuration:

- New kanshi.nix module runs kanshi as a sway-session user service with a docked/undocked profile config; kanshi and wdisplays move here from waybar.nix.
- New waybar-displays package bundles three scripts: waybar-displays (icon), kanshi-active (records the active profile and signals Waybar), and kanshi-toggle (docked <-> undocked on right-click).
- The custom/displays widget shows a laptop icon when undocked and a monitor icon when docked. It refreshes on SIGRTMIN+4 and polls every 60s so a missed signal self-heals.
- The docked profile mirrors the current physical layout; the external monitor is matched by make/model/serial, the laptop panel by name.
- Extend tests/waybar.nix to cover the widget wiring, the service PATH, the icon selection, and kanshi-active's state file.