### PR TITLE
Add fuzzel as screencast chooser for wlr portal

### DIFF
--- a/nixosModules/fuzzel.nix
+++ b/nixosModules/fuzzel.nix
@@ -5,13 +5,25 @@
   ...
 }:
 let
-  inherit (lib) mkEnableOption mkIf mkPackageOption;
+  inherit (lib)
+    mkDefault
+    mkEnableOption
+    mkIf
+    mkPackageOption
+    ;
   cfg = config.thoughtfull.programs.fuzzel;
+  wlr = config.xdg.portal.wlr;
 in
 {
-  config.environment = mkIf cfg.enable {
-    etc."xdg/fuzzel/fuzzel.ini".source = ./fuzzel/fuzzel.ini;
-    systemPackages = [ cfg.package ];
+  config = mkIf cfg.enable {
+    environment = {
+      etc."xdg/fuzzel/fuzzel.ini".source = ./fuzzel/fuzzel.ini;
+      systemPackages = [ cfg.package ];
+    };
+    xdg.portal.wlr.settings.screencast = mkIf wlr.enable {
+      chooser_type = mkDefault "dmenu";
+      chooser_cmd = mkDefault "/run/current-system/sw/bin/fuzzel -d --width 80";
+    };
   };
   options.thoughtfull.programs.fuzzel = {
     enable = mkEnableOption "fuzzel";


### PR DESCRIPTION
Configure the wlr xdg-desktop-portal to use fuzzel as the dmenu chooser for screencast source selection when the portal is enabled.