### PR TITLE
Persist Nix trusted-settings across reboots

### DIFF
--- a/nixosModules/default.nix
+++ b/nixosModules/default.nix
@@ -130,6 +130,7 @@ in
     syncthing.enable = mkDefault true;
   };
   thoughtfull = {
+    impermanence.user.directories = [ ".local/share/nix" ];
     monitoring = {
       enable = mkDefault true;
       services = [

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -22,7 +22,7 @@ extendedNixpkgs.testers.nixosTest {
 
   nodes = {
     machine =
-      { lib, ... }:
+      { config, lib, ... }:
       {
         imports = [ defaultModule ];
         # name must match the default keysHash so githubKeys hits the Nix store
@@ -38,6 +38,14 @@ extendedNixpkgs.testers.nixosTest {
           impermanence.enable = lib.mkForce false;
           monitoring.enable = lib.mkForce false;
         };
+        assertions = [
+          {
+            assertion = builtins.any (
+              d: (d.directory or d) == ".local/share/nix"
+            ) config.thoughtfull.impermanence.user.directories;
+            message = "expected nix trusted-settings persistence directory .local/share/nix";
+          }
+        ];
       };
   };
 


### PR DESCRIPTION
nixos-rebuild evaluates the flake as the invoking user, who is prompted to accept the flake's nixConfig substituters and public keys. The acceptance is written to ~/.local/share/nix/trusted-settings.json, but that path was not persisted, so impermanence wiped it on every reboot and the prompt returned each rebuild.

Persist .local/share/nix so the accepted settings survive reboots.