### PR TITLE
Run system-pull switch in-process for unified logging

### DIFF
--- a/nixosModules/system-pull.nix
+++ b/nixosModules/system-pull.nix
@@ -30,16 +30,27 @@ in
       }
     ];
 
+    environment.systemPackages = [ pkgs.thoughtfull.system-pull ];
+
     systemd.services.system-pull = {
       description = mkDefault "Pull the latest system closure from the binary cache";
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
       restartIfChanged = mkDefault false;
+      # Keep the running instance alive if a pulled generation removes this
+      # unit: otherwise activation would stop it (X-StopOnRemoval defaults to
+      # true) and kill the switch it is running in-process.
+      unitConfig.X-StopOnRemoval = mkDefault false;
       serviceConfig = {
         Type = mkDefault "oneshot";
         User = mkDefault "root";
         EnvironmentFile = mkDefault config.age.secrets.nix-cache-credentials.path;
-        ExecStart = mkDefault "${pkgs.thoughtfull.system-pull}/bin/system-pull ${binaryCache.bucket} ${binaryCache.region}";
+        # Reference system-pull through /run/current-system so the ExecStart is
+        # a stable path that does not change on every rebuild. This keeps the
+        # unit byte-identical across generations, so switch-to-configuration
+        # leaves it untouched during activation and does not kill the in-flight
+        # switch the script runs in-process.
+        ExecStart = mkDefault "/run/current-system/sw/bin/system-pull ${binaryCache.bucket} ${binaryCache.region}";
       };
     };
 

--- a/nixosModules/system-pull.nix
+++ b/nixosModules/system-pull.nix
@@ -14,6 +14,12 @@ let
     types
     ;
   hasCredentials = binaryCache.enable && binaryCache.awsCredentialsFile != null;
+  # Bake the host's bucket, region, and credentials path into the script so it
+  # runs with no arguments.
+  system-pull = pkgs.thoughtfull.system-pull.override {
+    inherit (binaryCache) bucket region;
+    credentialsFile = config.age.secrets.nix-cache-credentials.path;
+  };
 in
 {
   config = mkIf cfg.enable {
@@ -30,7 +36,7 @@ in
       }
     ];
 
-    environment.systemPackages = [ pkgs.thoughtfull.system-pull ];
+    environment.systemPackages = [ system-pull ];
 
     systemd.services.system-pull = {
       description = mkDefault "Pull the latest system closure from the binary cache";
@@ -44,13 +50,20 @@ in
       serviceConfig = {
         Type = mkDefault "oneshot";
         User = mkDefault "root";
-        EnvironmentFile = mkDefault config.age.secrets.nix-cache-credentials.path;
+        # Deliberately no EnvironmentFile: the AWS credentials are only needed
+        # for the pointer fetch, so the script loads them (via dotenvy) scoped
+        # to just that command. Putting them in the unit environment would
+        # expose them to switch-to-configuration and every activation script it
+        # runs in-process. nix-daemon still gets its own EnvironmentFile (see
+        # binary-cache.nix) to substitute the closure from the cache.
+        #
         # Reference system-pull through /run/current-system so the ExecStart is
         # a stable path that does not change on every rebuild. This keeps the
         # unit byte-identical across generations, so switch-to-configuration
         # leaves it untouched during activation and does not kill the in-flight
-        # switch the script runs in-process.
-        ExecStart = mkDefault "/run/current-system/sw/bin/system-pull ${binaryCache.bucket} ${binaryCache.region}";
+        # switch the script runs in-process. The script takes no arguments; its
+        # bucket, region, and credentials path are baked in above.
+        ExecStart = mkDefault "/run/current-system/sw/bin/system-pull";
       };
     };
 

--- a/packages/system-pull.nix
+++ b/packages/system-pull.nix
@@ -1,25 +1,52 @@
 { lib, pkgs }:
 let
-  inherit (pkgs)
-    awscli2
-    bash
-    coreutils
-    hostname-debian
-    jq
-    nix
-    ;
+  inherit (pkgs.lib) makeOverridable;
   inherit (lib) writeFileScriptBin;
 in
-writeFileScriptBin {
-  name = "system-pull";
-  replacements = {
-    aws = "${awscli2}/bin/aws";
-    bash = "${bash}/bin/bash";
-    hostname = "${hostname-debian}/bin/hostname";
-    jq = "${jq}/bin/jq";
-    nix_env = "${nix}/bin/nix-env";
-    nix_store = "${nix}/bin/nix-store";
-    readlink = "${coreutils}/bin/readlink";
-  };
-  src = ./system-pull/system-pull.bash;
-}
+makeOverridable
+  (
+    {
+      awscli2,
+      bash,
+      bucket,
+      coreutils,
+      credentialsFile,
+      dotenvy,
+      hostname-debian,
+      jq,
+      nix,
+      region,
+    }:
+    writeFileScriptBin {
+      name = "system-pull";
+      replacements = {
+        aws = "${awscli2}/bin/aws";
+        bash = "${bash}/bin/bash";
+        inherit bucket region;
+        credentials_file = credentialsFile;
+        dotenvy = "${dotenvy}/bin/dotenvy";
+        hostname = "${hostname-debian}/bin/hostname";
+        jq = "${jq}/bin/jq";
+        nix_env = "${nix}/bin/nix-env";
+        nix_store = "${nix}/bin/nix-store";
+        readlink = "${coreutils}/bin/readlink";
+      };
+      src = ./system-pull/system-pull.bash;
+    }
+  )
+  {
+    inherit (pkgs)
+      awscli2
+      bash
+      coreutils
+      dotenvy
+      hostname-debian
+      jq
+      nix
+      ;
+    # Defaults match thoughtfull.binaryCache; the system-pull module overrides
+    # these with the host's actual configuration.
+    bucket = "thoughtfull-nix-cache";
+    credentialsFile = "/run/agenix/nix-cache-credentials";
+    region = "us-east-1";
+  }

--- a/packages/system-pull.nix
+++ b/packages/system-pull.nix
@@ -7,7 +7,6 @@ let
     hostname-debian
     jq
     nix
-    systemd
     ;
   inherit (lib) writeFileScriptBin;
 in
@@ -21,7 +20,6 @@ writeFileScriptBin {
     nix_env = "${nix}/bin/nix-env";
     nix_store = "${nix}/bin/nix-store";
     readlink = "${coreutils}/bin/readlink";
-    systemd_run = "${systemd}/bin/systemd-run";
   };
   src = ./system-pull/system-pull.bash;
 }

--- a/packages/system-pull/system-pull.bash
+++ b/packages/system-pull/system-pull.bash
@@ -44,17 +44,13 @@ echo "system-pull: registering system profile generation"
 @nix_env@ -p /nix/var/nix/profiles/system --set "${target}"
 
 echo "system-pull: switching configuration"
-# Run switch-to-configuration in a transient unit so the switch survives
-# activation-time stop/restart of system-pull.service itself.
-@systemd_run@ \
-  -E LOCALE_ARCHIVE \
-  --collect \
-  --no-ask-password \
-  --pipe \
-  --quiet \
-  --service-type=exec \
-  --unit=system-pull-switch-to-configuration \
-  -- \
-  "${target}/bin/switch-to-configuration" switch
+# Run switch-to-configuration directly, in-process, so its output is captured
+# in system-pull.service's own journal. This relies on the service being
+# shielded from activation stopping it out from under the switch: a stable
+# ExecStart (/run/current-system/sw/bin/system-pull) keeps the unit
+# byte-identical across generations (so it isn't restarted), restartIfChanged
+# skips it if it does change, and X-StopOnRemoval=false keeps it running if a
+# generation removes it.
+"${target}/bin/switch-to-configuration" switch
 
 echo "system-pull: switched to ${target}"

--- a/packages/system-pull/system-pull.bash
+++ b/packages/system-pull/system-pull.bash
@@ -2,27 +2,29 @@
 set -euo pipefail
 
 # Pull the latest signed system closure for this host from the S3 binary
-# cache and switch to it. Intended to run as root from a systemd timer.
+# cache and switch to it. Intended to run as root from a systemd timer, but
+# also runnable by hand with sudo. Takes no arguments: the bucket, region, and
+# credentials-file path are baked in at build time by the system-pull module.
 #
-# Usage: system-pull <bucket> <region>
-#
-# Reads AWS credentials from the environment (the systemd unit sets
-# EnvironmentFile to the agenix-decrypted credentials file). Falls back to
-# the early exit if /run/current-system already points at the target.
+# The credentials file is an agenix-decrypted EnvironmentFile (KEY=value)
+# holding this host's read-only AWS credentials. It is loaded into the
+# environment of only the pointer fetch, via dotenvy, so the credentials never
+# reach switch-to-configuration or the activation scripts it runs. dotenvy
+# parses the file rather than sourcing it; note it expands $VAR references
+# (systemd's EnvironmentFile does not), which is harmless for base64 AWS keys.
+# The file is root-only, so an unprivileged run fails at the fetch. Realising
+# the closure needs no credentials here: nix-daemon substitutes it using its
+# own EnvironmentFile (see binary-cache.nix).
 
-if [[ $# -ne 2 ]]; then
-  echo "usage: system-pull <bucket> <region>" >&2
-  exit 64
-fi
-
-bucket=$1
-region=$2
+bucket="@bucket@"
+region="@region@"
+creds_file="@credentials_file@"
 hostname=$(@hostname@)
 
 pointer_url="s3://${bucket}/hosts/${hostname}/latest.json"
 echo "system-pull: fetching ${pointer_url}"
 
-pointer=$(@aws@ s3 cp "${pointer_url}" - --region "${region}")
+pointer=$(@dotenvy@ -f "${creds_file}" @aws@ s3 cp "${pointer_url}" - --region "${region}")
 target=$(printf '%s\n' "${pointer}" | @jq@ -r '.storePath')
 
 if [[ -z ${target} || ${target} == "null" ]]; then

--- a/tests/system-pull.nix
+++ b/tests/system-pull.nix
@@ -109,39 +109,56 @@ nixpkgs.testers.nixosTest {
             "graphical host should fire at noon"
         )
 
-    with subtest("service uses agenix-decrypted EnvironmentFile"):
+    with subtest("service uses agenix-decrypted EnvironmentFile and a stable ExecStart"):
         unit = headless.succeed("systemctl cat system-pull.service")
         print(f"headless service:\n{unit}")
         assert "EnvironmentFile=/run/agenix/nix-cache-credentials" in unit, (
             "service should source AWS credentials from agenix path"
         )
-        assert "ExecStart=" in unit and "/bin/system-pull thoughtfull-nix-cache us-east-1" in unit, (
-            f"ExecStart should invoke system-pull with bucket and region; got:\n{unit}"
+        exec_line = next(
+            line for line in unit.splitlines() if line.startswith("ExecStart=")
+        )
+        assert exec_line == (
+            "ExecStart=/run/current-system/sw/bin/system-pull "
+            "thoughtfull-nix-cache us-east-1"
+        ), f"ExecStart should be the stable current-system path; got:\n{exec_line}"
+        assert "/nix/store/" not in exec_line, (
+            "ExecStart must not embed a store path, or activation would "
+            "stop system-pull.service mid-switch"
         )
 
-    with subtest("switch-to-configuration runs in a transient unit detached from system-pull.service"):
-        # The script must wrap switch-to-configuration with systemd-run so the
-        # switch survives activation-time stop of system-pull.service itself.
+    with subtest("service opts out of stop-on-removal so an in-flight switch survives"):
+        # If a pulled generation removes system-pull.service, activation would
+        # otherwise SIGTERM it (X-StopOnRemoval defaults true) and kill the
+        # in-process switch. X-StopOnRemoval=false keeps the running instance
+        # alive until the switch it is running finishes.
+        unit = headless.succeed("systemctl cat system-pull.service")
+        assert "X-StopOnRemoval=false" in unit, (
+            "service must set X-StopOnRemoval=false so activation cannot stop "
+            "it mid-switch when a pulled generation removes the unit"
+        )
+
+    with subtest("switch-to-configuration runs in-process, not via systemd-run"):
+        # The stable ExecStart keeps system-pull.service byte-identical across
+        # generations, so activation leaves it untouched. The switch can then
+        # run in-process and its output lands in system-pull.service's journal.
         exec_start = headless.succeed(
             "systemctl show system-pull.service -p ExecStart --value"
         )
         script_path = exec_start.split("argv[]=")[1].split()[0]
         script = headless.succeed(f"cat {script_path}")
         print(f"system-pull script:\n{script}")
-        # Strip comment lines so the ordering check isn't fooled by prose.
+        # Strip comment lines so the check isn't fooled by prose.
         code = "\n".join(
             line for line in script.splitlines() if not line.lstrip().startswith("#")
-        )
-        assert "systemd-run" in code, (
-            "system-pull must invoke switch-to-configuration via systemd-run "
-            "so activation can stop/restart system-pull.service without killing "
-            "the in-flight switch"
         )
         assert "switch-to-configuration" in code, (
             "system-pull must invoke switch-to-configuration"
         )
-        assert code.index("systemd-run") < code.index("switch-to-configuration"), (
-            "systemd-run must wrap the switch-to-configuration invocation"
+        assert "systemd-run" not in code, (
+            "system-pull must invoke switch-to-configuration in-process; the "
+            "stable ExecStart means activation won't kill it, so the "
+            "systemd-run transient-unit wrapper is no longer needed"
         )
 
     with subtest("nix.conf gets s3:// substituter and trusted public key"):

--- a/tests/system-pull.nix
+++ b/tests/system-pull.nix
@@ -109,19 +109,22 @@ nixpkgs.testers.nixosTest {
             "graphical host should fire at noon"
         )
 
-    with subtest("service uses agenix-decrypted EnvironmentFile and a stable ExecStart"):
+    with subtest("service invokes system-pull with no arguments and keeps creds out of its environment"):
         unit = headless.succeed("systemctl cat system-pull.service")
         print(f"headless service:\n{unit}")
-        assert "EnvironmentFile=/run/agenix/nix-cache-credentials" in unit, (
-            "service should source AWS credentials from agenix path"
+        assert "EnvironmentFile=" not in unit, (
+            "AWS credentials must not be loaded into system-pull.service's "
+            "environment: they would leak into switch-to-configuration and the "
+            "activation scripts it runs. The script loads them scoped to the "
+            "pointer fetch instead."
         )
         exec_line = next(
             line for line in unit.splitlines() if line.startswith("ExecStart=")
         )
-        assert exec_line == (
-            "ExecStart=/run/current-system/sw/bin/system-pull "
-            "thoughtfull-nix-cache us-east-1"
-        ), f"ExecStart should be the stable current-system path; got:\n{exec_line}"
+        assert exec_line == "ExecStart=/run/current-system/sw/bin/system-pull", (
+            "ExecStart should invoke system-pull with no arguments (bucket, "
+            f"region, and creds path are baked in); got:\n{exec_line}"
+        )
         assert "/nix/store/" not in exec_line, (
             "ExecStart must not embed a store path, or activation would "
             "stop system-pull.service mid-switch"
@@ -159,6 +162,43 @@ nixpkgs.testers.nixosTest {
             "system-pull must invoke switch-to-configuration in-process; the "
             "stable ExecStart means activation won't kill it, so the "
             "systemd-run transient-unit wrapper is no longer needed"
+        )
+
+    with subtest("credentials are loaded scoped via dotenvy, not sourced"):
+        # AWS creds are only needed for the pointer fetch, so load them into the
+        # environment of just that command with dotenvy (which parses the file
+        # rather than executing it) instead of sourcing the file or exporting
+        # the creds process-wide via EnvironmentFile.
+        exec_start = headless.succeed(
+            "systemctl show system-pull.service -p ExecStart --value"
+        )
+        script_path = exec_start.split("argv[]=")[1].split()[0]
+        script = headless.succeed(f"cat {script_path}")
+        code = "\n".join(
+            line for line in script.splitlines() if not line.lstrip().startswith("#")
+        )
+        assert "dotenvy -f" in code, (
+            "system-pull must load AWS credentials with 'dotenvy -f <file>' "
+            "scoped to the command that needs them"
+        )
+        assert "source " not in code, (
+            "system-pull must not source the credentials file"
+        )
+
+    with subtest("bucket, region, and credentials path are baked into the script"):
+        exec_start = headless.succeed(
+            "systemctl show system-pull.service -p ExecStart --value"
+        )
+        script_path = exec_start.split("argv[]=")[1].split()[0]
+        script = headless.succeed(f"cat {script_path}")
+        assert 'bucket="thoughtfull-nix-cache"' in script, (
+            f"bucket should be baked in; got:\n{script}"
+        )
+        assert 'region="us-east-1"' in script, (
+            f"region should be baked in; got:\n{script}"
+        )
+        assert 'creds_file="/run/agenix/nix-cache-credentials"' in script, (
+            f"credentials path should be baked in; got:\n{script}"
         )
 
     with subtest("nix.conf gets s3:// substituter and trusted public key"):


### PR DESCRIPTION
system-pull wrapped switch-to-configuration in a systemd-run transient unit so activation could not kill the in-flight switch when it stopped system-pull.service (whose ExecStart store path changes every rebuild). The cost was that the switch ran in its own cgroup, so its output landed under system-pull-switch-to-configuration.service instead of system-pull.service -- invisible in the service journal and its failure alert.

Reference system-pull through the stable /run/current-system/sw/bin path instead, so the unit is byte-identical across generations and switch-to-configuration leaves it untouched during activation. The switch can then run directly, in-process, and its output flows into system-pull.service's own journal.

Shield the service from the remaining way activation could stop it: X-StopOnRemoval=false keeps the running instance alive if a pulled generation removes the unit (restartIfChanged=false already covers changes; the stable ExecStart covers the common case).