### PR TITLE
Give system-pull's closure realise its AWS credentials

### DIFF
--- a/nixosModules/system-pull.nix
+++ b/nixosModules/system-pull.nix
@@ -51,11 +51,13 @@ in
         Type = mkDefault "oneshot";
         User = mkDefault "root";
         # Deliberately no EnvironmentFile: the AWS credentials are only needed
-        # for the pointer fetch, so the script loads them (via dotenvy) scoped
-        # to just that command. Putting them in the unit environment would
-        # expose them to switch-to-configuration and every activation script it
-        # runs in-process. nix-daemon still gets its own EnvironmentFile (see
-        # binary-cache.nix) to substitute the closure from the cache.
+        # to fetch the pointer and realise the closure, so the script loads
+        # them (via dotenvy) scoped to just those two commands. Putting them in
+        # the unit environment would expose them to switch-to-configuration and
+        # every activation script it runs in-process. The realise carries the
+        # credentials itself because system-pull runs as root, whose `auto`
+        # store realises in-process rather than through nix-daemon, so the
+        # daemon's own EnvironmentFile (see binary-cache.nix) does not apply.
         #
         # Reference system-pull through /run/current-system so the ExecStart is
         # a stable path that does not change on every rebuild. This keeps the

--- a/packages/system-pull/system-pull.bash
+++ b/packages/system-pull/system-pull.bash
@@ -7,14 +7,18 @@ set -euo pipefail
 # credentials-file path are baked in at build time by the system-pull module.
 #
 # The credentials file is an agenix-decrypted EnvironmentFile (KEY=value)
-# holding this host's read-only AWS credentials. It is loaded into the
-# environment of only the pointer fetch, via dotenvy, so the credentials never
-# reach switch-to-configuration or the activation scripts it runs. dotenvy
-# parses the file rather than sourcing it; note it expands $VAR references
-# (systemd's EnvironmentFile does not), which is harmless for base64 AWS keys.
-# The file is root-only, so an unprivileged run fails at the fetch. Realising
-# the closure needs no credentials here: nix-daemon substitutes it using its
-# own EnvironmentFile (see binary-cache.nix).
+# holding this host's read-only AWS credentials. It is loaded, via dotenvy,
+# into the environment of only the two commands that reach the S3 cache -- the
+# pointer fetch and the closure realise -- so the credentials never reach
+# switch-to-configuration or the activation scripts it runs. dotenvy parses the
+# file rather than sourcing it; note it expands $VAR references (systemd's
+# EnvironmentFile does not), which is harmless for base64 AWS keys. The file is
+# root-only, so an unprivileged run fails at the fetch.
+#
+# The realise needs the credentials directly: system-pull runs as root, whose
+# `auto` store realises in-process rather than through nix-daemon, so
+# `nix-store --realise` substitutes from the S3 cache in this process and the
+# daemon's own EnvironmentFile (see binary-cache.nix) does not apply to it.
 
 bucket="@bucket@"
 region="@region@"
@@ -40,7 +44,7 @@ if [[ ${target} == "${current}" ]]; then
 fi
 
 echo "system-pull: realising ${target}"
-@nix_store@ --realise "${target}"
+@dotenvy@ -f "${creds_file}" @nix_store@ --realise "${target}"
 
 echo "system-pull: registering system profile generation"
 @nix_env@ -p /nix/var/nix/profiles/system --set "${target}"

--- a/tests/system-pull.nix
+++ b/tests/system-pull.nix
@@ -185,6 +185,37 @@ nixpkgs.testers.nixosTest {
             "system-pull must not source the credentials file"
         )
 
+    with subtest("the closure is realised with credentials scoped to that command"):
+        # system-pull runs as root, whose `auto` store realises in-process
+        # rather than through nix-daemon, so `nix-store --realise` substitutes
+        # from the s3:// cache in its own process and must carry the AWS
+        # credentials itself -- the daemon's EnvironmentFile does not apply.
+        # Load them with dotenvy scoped to just the realise, so they stay out
+        # of switch-to-configuration and the activation scripts it runs.
+        exec_start = headless.succeed(
+            "systemctl show system-pull.service -p ExecStart --value"
+        )
+        script_path = exec_start.split("argv[]=")[1].split()[0]
+        script = headless.succeed(f"cat {script_path}")
+        code = "\n".join(
+            line for line in script.splitlines() if not line.lstrip().startswith("#")
+        )
+        realise_line = next(
+            line for line in code.splitlines() if "--realise" in line
+        )
+        assert "dotenvy -f" in realise_line, (
+            "nix-store --realise must be wrapped with 'dotenvy -f <file>' so "
+            "the in-process substitution from the s3:// cache has AWS "
+            f"credentials; got:\n{realise_line}"
+        )
+        switch_line = next(
+            line for line in code.splitlines() if "switch-to-configuration" in line
+        )
+        assert "dotenvy" not in switch_line, (
+            "switch-to-configuration must not receive the AWS credentials: "
+            "they are only needed to fetch the pointer and realise the closure"
+        )
+
     with subtest("bucket, region, and credentials path are baked into the script"):
         exec_start = headless.succeed(
             "systemctl show system-pull.service -p ExecStart --value"


### PR DESCRIPTION
## Give system-pull's closure realise its AWS credentials

### Problem

`sudo system-pull` fetched the pointer fine but failed to realise the closure:

```
system-pull: realising /nix/store/…-nixos-system-aegle-…
warning: AWS authentication failed for S3 request …: AWS authentication error:
  'Valid credentials could not be sourced by the IMDS provider'
… HTTP error 403 … <Code>AccessDenied</Code>
error: … there is no substituter that can build it
```

### Root cause

`system-pull` runs as root, whose `auto` Nix store (with `NIX_REMOTE` unset)
realises **in-process** rather than through `nix-daemon`. So `nix-store
--realise` substitutes from the `s3://` cache in the script's own process.

Commit fc1eaa0 scoped the AWS credentials to only the `dotenvy`-wrapped pointer
fetch, on the premise that "nix-daemon substitutes the closure with its own
EnvironmentFile." That premise is wrong for a root caller — the realise never
reaches the daemon, so it ran unauthenticated, made anonymous S3 requests, fell
through the whole credential chain to IMDS, and got 403s.

Everything else was a red herring: the closure was pushed and signed by CI, the
IAM read key can read the whole bucket, the trusted key is present, and the
daemon's `EnvironmentFile` is correctly wired — none of it matters because
root's realise doesn't use the daemon.

### Fix

Wrap the realise with `dotenvy` too, exactly like the pointer fetch, so it
carries the credentials in its own environment:

```diff
-@nix_store@ --realise "${target}"
+@dotenvy@ -f "${creds_file}" @nix_store@ --realise "${target}"
```

`switch-to-configuration` still runs **without** the credentials, so they stay
out of the activation scripts — the property fc1eaa0's scoping was protecting.
Comments in the script and the `system-pull.nix` module are updated to reflect
the actual mechanism.

### Verification

- New `tests/system-pull.nix` subtest asserts the `--realise` line carries
  `dotenvy -f` and the `switch-to-configuration` line does not; it fails on the
  old script and passes on the fixed one
  (`nix build .#checks.x86_64-linux.system-pull`).
- Pre-commit hooks pass.
- Confirmed on a live host: `AWS_ACCESS_KEY_ID=… AWS_SECRET_ACCESS_KEY=…
  nix-store --realise …` fetched all 12 closure paths from S3 and completed.

### Note

The daemon's `EnvironmentFile` is unchanged (still relevant for non-root cache
use). A separate observation — the socket-activated `nix-daemon` can come up at
boot without its S3 credentials — is out of scope here and worth its own
follow-up.
