### PR TITLE
Fix waybar tray icon sometimes rendering with the wrong theme

### DIFF
--- a/nixosModules/sway.nix
+++ b/nixosModules/sway.nix
@@ -100,6 +100,10 @@ in
       wantedBy = [ "sway-session.target" ];
       serviceConfig = {
         Type = "oneshot";
+        # Keeps `systemctl --user status` showing active/exited instead of
+        # inactive (dead) after this ad-hoc-restarted unit runs, so it doesn't
+        # look like it never ran or failed when debugging theming issues.
+        RemainAfterExit = true;
         # sway reruns this on every config reload via `systemctl --user restart
         # gtk-defaults.service`, so waybar (ordered `after` this unit) never
         # starts before the GTK icon/cursor/font theme is actually applied.

--- a/nixosModules/sway.nix
+++ b/nixosModules/sway.nix
@@ -90,6 +90,29 @@ in
     gnome-settings-daemon.enable = mkDefault sway.enable;
   };
   systemd.user.services = {
+    gtk-defaults = {
+      after = [ "sway-session.target" ];
+      # partOf (not bindsTo): this unit must never *pull up* sway-session.target
+      # by being restarted (see the exec_always in sway/config) -- only follow
+      # it down when the session itself stops/restarts.
+      partOf = [ "sway-session.target" ];
+      enable = mkDefault sway.enable;
+      wantedBy = [ "sway-session.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        # sway reruns this on every config reload via `systemctl --user restart
+        # gtk-defaults.service`, so waybar (ordered `after` this unit) never
+        # starts before the GTK icon/cursor/font theme is actually applied.
+        # Each command is "-"-prefixed so one failure doesn't skip the rest.
+        ExecStart = mkDefault [
+          "-${glib}/bin/gsettings set org.gnome.desktop.interface gtk-theme Adwaita"
+          "-${glib}/bin/gsettings set org.gnome.desktop.interface icon-theme Numix"
+          "-${glib}/bin/gsettings set org.gnome.desktop.interface cursor-theme Numix"
+          "-${glib}/bin/gsettings set org.gnome.desktop.interface cursor-size 32"
+          "-${glib}/bin/gsettings set org.gnome.desktop.interface font-name Numix"
+        ];
+      };
+    };
     sway-autotiling = {
       after = [ "sway-session.target" ];
       bindsTo = [ "sway-session.target" ];

--- a/nixosModules/sway/config
+++ b/nixosModules/sway/config
@@ -4,15 +4,10 @@
 #
 # Read `man 5 sway` for a complete reference.
 
-set $gnome-schema org.gnome.desktop.interface
-
-exec_always {
-    gsettings set $gnome-schema gtk-theme 'Adwaita'
-    gsettings set $gnome-schema icon-theme 'Numix'
-    gsettings set $gnome-schema cursor-theme 'Numix'
-    gsettings set $gnome-schema cursor-size 32
-    gsettings set $gnome-schema font-name 'Numix'
-}
+# GTK theme/icon-theme/cursor-theme/font defaults live in the gtk-defaults
+# systemd unit (see sway.nix) so waybar can order after it and is guaranteed
+# to start only once the theme is actually applied.
+exec_always "systemctl --user restart gtk-defaults.service"
 
 seat * xcursor_theme Numix 32
 

--- a/nixosModules/sway/waybar.nix
+++ b/nixosModules/sway/waybar.nix
@@ -76,16 +76,19 @@ in
           RestartSec = 1;
         };
       };
-      waybar.path = [
-        bash
-        curl
-        gtklock.package
-        power-menu
-        theme-toggle
-        waybar-displays
-        waybar-yubikey
-        wdisplays
-      ];
+      waybar = {
+        after = [ "gtk-defaults.service" ];
+        path = [
+          bash
+          curl
+          gtklock.package
+          power-menu
+          theme-toggle
+          waybar-displays
+          waybar-yubikey
+          wdisplays
+        ];
+      };
     };
   };
 }


### PR DESCRIPTION
## Summary
- waybar starts as a systemd user service bound to `sway-session.target`, independently of sway's `exec_always` gsettings calls that set the GTK icon theme (Numix). waybar could resolve/render the pasystray tray icon before the theme was actually applied, requiring a manual `waybar` restart to fix it (waybar caches the rendered tray icon and doesn't re-render on a later theme change).
- Moves the `gsettings set` calls into a new `gtk-defaults` oneshot systemd unit and orders `waybar` `after` it, so the theme is guaranteed to be applied before waybar's first tray render. sway's `exec_always` now just does `systemctl --user restart gtk-defaults.service`, reapplying the theme on every reload without restarting waybar.
- `gtk-defaults` uses `PartOf` (not `BindsTo`) on `sway-session.target` so restarting it from the `exec_always` can't prematurely pull `sway-session.target` up ahead of the real session-environment-import sequence in `nixos.conf`. Each `gsettings` call is `-`-prefixed so one failure doesn't block the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)