### PR TITLE
Free disk space before Nix build in build-and-push

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -31,6 +31,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Free disk space
+        # jlumbroso/free-disk-space targets the x64 hosted runner image; the
+        # arm runner has a different (smaller) preinstalled toolset and
+        # plenty of headroom already, so skip it there.
+        if: matrix.runner == 'ubuntu-24.04'
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           swap-storage: false

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -30,6 +30,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          swap-storage: false
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
         with:


### PR DESCRIPTION
## Summary
- The nightly/on-push `build-and-push` workflow was hitting "No space left on device" while substituting large desktop closures (hydor's is 16.7 GiB) on standard GitHub-hosted runners.
- Adds `jlumbroso/free-disk-space` before the Nix install step to reclaim preinstalled cruft (Android SDK, .NET, etc.) that isn't needed for this build.
- Explicitly sets `swap-storage: false` to keep the runner's swapfile intact, so a memory spike during Nix evaluation/NAR extraction degrades instead of risking an OOM-kill.