### PR TITLE
Default sway workspaces to tabbed layout

### DIFF
--- a/nixosModules/sway/config
+++ b/nixosModules/sway/config
@@ -13,6 +13,7 @@ seat * xcursor_theme Numix 32
 
 default_border pixel 3
 gaps inner 10
+workspace_layout tabbed
 
 # Adwaita colors (focused and urgent are the same for light/dark)
 #              <border> <background> <text> [<indicator> [<child_border>]]


### PR DESCRIPTION
## Summary
- Set `workspace_layout tabbed` in the sway config so new/empty workspaces start with a tabbed layout instead of the default split layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)