### PR TITLE
Add Waybar network widgets

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -124,6 +124,7 @@
             uns
             usb-menu
             waybar-displays
+            waybar-network
             waybar-weather
             waybar-yubikey
             yubikey-totp

--- a/nixosConfigurations/hydor.nix
+++ b/nixosConfigurations/hydor.nix
@@ -32,6 +32,7 @@
             swap.size = "4G";
           };
           user.hashedPasswordFile = ./hydor/secrets/hashed-user-passphrase.age;
+          vpn.configFile = ./hydor/secrets/vpn-config.age;
         };
       }
     )

--- a/nixosConfigurations/hydor/secrets/vpn-config.age
+++ b/nixosConfigurations/hydor/secrets/vpn-config.age
@@ -1,0 +1,10 @@
+age-encryption.org/v1
+-> piv-p256 2ONmvQ AuSfMtQ4Icgt6NGTmCjw4c1ONomGq6Vot0PUvaXTBmCp
+ty7AZs92wONTJZfY4oRrHun1URZPKYBnHO4J6pd8XA4
+-> piv-p256 5HigPA A0AdeRhImpvwHmcbRu5m8+eTHoZ7LhmQPTucrt+s2IwO
+WKYOsWiiUy4r6Pf+GnS1JD1PUH4GhA7uO/zgdi91dRQ
+-> ssh-ed25519 kvlwRQ bY6FN0p1t2F82aW61P1B1uatqSvu3MIO3urujVF7XAs
+sFpPnxw+AV84X1O960786+MKVfUKJZNESPDQjpyufXs
+--- OA/P5JmFwhGzRngsw17Pb4GWkGdHRxOx8pZGeHGt0+c
+tm³ÐïH‚buHrKêß±rH;r#$ƒïÕ/Zwu>Êü×v\L_ FØ G~È×LEÞŽÌõ
+µœl+(^hˆ R2R+(/®Ò‘JN‘3Ì•RëD{[R×.1g}6#ŸÎHÉ_³›½‹ šP–QÉ—‰»A<B#T1¥äR	Ñ_â2 Öü~jX•9Ö6€,­$)òÿ¡qHÛó 	×Ô¢±:Ï»@ÖjÕ©Ñ÷98–$ÕÛÑÏ¾Üoz€úÒ€û®×eõz>VÎ¨åôÏ×,L²6BüT,ë‚!·3²Ù†àKŠBFh™~#ëáCïXB=R’‘gÀ†•}Šó*&@Ãÿ€œÜâ±Õ…7µ+ó}I„“öAÊŠ£_4ï

--- a/nixosModules/graphical.nix
+++ b/nixosModules/graphical.nix
@@ -11,7 +11,13 @@ in
   config = mkIf graphical.enable {
     gtk.iconCache.enable = mkDefault true;
     hardware.bluetooth.enable = mkDefault true;
-    networking.networkmanager.enable = mkDefault true;
+    networking = {
+      networkmanager = {
+        enable = mkDefault true;
+        wifi.backend = mkDefault "iwd";
+      };
+      wireless.iwd.enable = mkDefault true;
+    };
     programs = {
       firefox.enable = mkDefault true;
       sway.enable = mkDefault true;
@@ -23,6 +29,7 @@ in
     systemd.user.services.mako.enable = mkDefault true;
     thoughtfull = {
       impermanence.user.directories = [ ".config/dconf" ];
+      user.extraGroups = [ "networkmanager" ];
       programs = {
         dictation.enable = mkDefault true;
         obsidian.enable = mkDefault true;

--- a/nixosModules/sway/waybar.nix
+++ b/nixosModules/sway/waybar.nix
@@ -17,7 +17,6 @@ let
     networkmanager
     networkmanagerapplet
     pasystray
-    procps
     waybar
     wdisplays
     ;
@@ -101,7 +100,6 @@ in
           networkmanager
           networkmanagerapplet
           power-menu
-          procps
           theme-toggle
           waybar-displays
           waybar-network

--- a/nixosModules/sway/waybar.nix
+++ b/nixosModules/sway/waybar.nix
@@ -12,12 +12,21 @@ let
     bash
     curl
     font-awesome
+    fuzzel
+    iwmenu
+    networkmanager
     networkmanagerapplet
     pasystray
+    procps
     waybar
     wdisplays
     ;
-  inherit (pkgs.thoughtfull) theme-toggle waybar-displays waybar-yubikey;
+  inherit (pkgs.thoughtfull)
+    theme-toggle
+    waybar-displays
+    waybar-network
+    waybar-yubikey
+    ;
   power-menu = pkgs.thoughtfull.power-menu.override { gtklock = gtklock.package; };
   cfg = config.programs.waybar;
 in
@@ -29,15 +38,17 @@ in
     };
     systemPackages = [
       font-awesome
+      iwmenu
+      networkmanager
       networkmanagerapplet
       pasystray
       power-menu
       waybar
+      waybar-network
       waybar-yubikey
     ];
   };
   programs = {
-    nm-applet.enable = mkDefault sway.enable;
     waybar = {
       enable = mkDefault sway.enable;
       systemd.target = mkDefault "sway-session.target";
@@ -84,10 +95,16 @@ in
         path = [
           bash
           curl
+          fuzzel
           gtklock.package
+          iwmenu
+          networkmanager
+          networkmanagerapplet
           power-menu
+          procps
           theme-toggle
           waybar-displays
+          waybar-network
           waybar-yubikey
           wdisplays
         ];

--- a/nixosModules/sway/waybar/config.jsonc
+++ b/nixosModules/sway/waybar/config.jsonc
@@ -6,7 +6,7 @@
 
   "modules-left": ["sway/workspaces", "sway/scratchpad" ],
   "modules-center": [],
-  "modules-right": ["sway/mode", "custom/yubikey", "custom/weather", "clock", "clock#utc", "battery", "tray", "custom/displays", "custom/theme", "custom/lock", "custom/power"],
+  "modules-right": ["sway/mode", "custom/yubikey", "custom/weather", "clock", "clock#utc", "battery", "custom/network-wifi", "custom/network-ethernet", "custom/network-vpn", "tray", "custom/displays", "custom/theme", "custom/lock", "custom/power"],
 
   "sway/workspaces": {
     "disable-scroll": false,
@@ -96,6 +96,36 @@
     "format": "<span font=\"20px\">󰐥</span>",
     "tooltip-format": "Power menu",
     "on-click": "power-menu --no-lock"
+  },
+
+  "custom/network-wifi": {
+    "format": "<span font=\"20px\">{}</span>",
+    "exec": "waybar-network-wifi",
+    "return-type": "json",
+    "interval": 15,
+    "on-click": "iwmenu --launcher fuzzel",
+    "on-click-middle": "waybar-network-wifi-toggle",
+    "on-click-right": "waybar-network-wifi-toggle"
+  },
+
+  "custom/network-ethernet": {
+    "format": "<span font=\"20px\">{}</span>",
+    "exec": "waybar-network-ethernet",
+    "return-type": "json",
+    "interval": 15,
+    "on-click": "waybar-network-ethernet-toggle",
+    "on-click-middle": "waybar-network-ethernet-toggle",
+    "on-click-right": "nm-connection-editor -t 802-3-ethernet -s"
+  },
+
+  "custom/network-vpn": {
+    "format": "<span font=\"20px\">{}</span>",
+    "exec": "waybar-network-vpn",
+    "return-type": "json",
+    "interval": 15,
+    "on-click": "waybar-network-vpn-toggle",
+    "on-click-middle": "waybar-network-vpn-toggle",
+    "on-click-right": "waybar-network-vpn-toggle"
   },
 
   "custom/displays": {

--- a/nixosModules/sway/waybar/style.css
+++ b/nixosModules/sway/waybar/style.css
@@ -50,9 +50,24 @@ window#waybar {
 #custom-yubikey,
 #custom-lock,
 #custom-power,
+#custom-network-ethernet,
+#custom-network-vpn,
 #mode,
 #tray {
   padding: 0 8pt;
+}
+
+#custom-network-wifi {
+  padding: 0 12pt 0 6pt;
+}
+
+#custom-network-wifi.disconnected,
+#custom-network-ethernet.disconnected,
+#custom-network-vpn.disconnected,
+#custom-network-wifi.disabled,
+#custom-network-ethernet.disabled,
+#custom-network-vpn.disabled {
+  color: @insensitive_fg_color;
 }
 
 #custom-yubikey {
@@ -109,6 +124,9 @@ window#waybar {
 #custom-displays:hover,
 #custom-theme:hover,
 #custom-lock:hover,
-#custom-power:hover {
+#custom-power:hover,
+#custom-network-wifi:hover,
+#custom-network-ethernet:hover,
+#custom-network-vpn:hover {
   background-color: @borders;
 }

--- a/nixosModules/vpn.nix
+++ b/nixosModules/vpn.nix
@@ -9,6 +9,13 @@ let
     mkOption
     types
     ;
+  # Single source of truth for the wg-quick interface name, so the systemd
+  # unit it implies can't drift out of sync between the aliases line and the
+  # polkit rule below. systemd.services attrset keys are bare unit names
+  # (NixOS appends ".service"); the polkit rule needs the full unit id.
+  iface = "wg0";
+  serviceName = "wg-quick-${iface}";
+  unit = "${serviceName}.service";
 in
 {
   config = {
@@ -16,14 +23,33 @@ in
       wg-quick-config.file = vpn.configFile;
     };
     networking.wg-quick.interfaces = mkIf vpn.enable {
-      wg0 = {
+      ${iface} = {
         autostart = mkDefault vpn.autostart;
         configFile = secrets.wg-quick-config.path;
       };
     };
     systemd.services = mkIf vpn.enable {
-      wg-quick-wg0.aliases = [ "vpn.service" ];
+      ${serviceName}.aliases = [ "vpn.service" ];
     };
+    # Lets a non-root user (e.g. the waybar-network-vpn-toggle widget) start
+    # and stop the VPN without a password prompt, scoped to exactly this
+    # unit rather than a blanket systemd grant.
+    security.polkit.enable = mkIf vpn.enable (mkDefault true);
+    # Not mkDefault: types.lines drops mkDefault-priority definitions
+    # entirely whenever another module sets this option at normal priority
+    # (e.g. networking.networkmanager's own extraConfig, enabled on every
+    # graphical host per nixosModules/graphical.nix) -- it doesn't merge in
+    # at lower precedence the way mkDefault does for single-value options.
+    security.polkit.extraConfig = mkIf vpn.enable ''
+      polkit.addRule(function(action, subject) {
+        var unit = action.lookup("unit");
+        if (action.id == "org.freedesktop.systemd1.manage-units" &&
+            (unit == "${unit}" || unit == "vpn.service") &&
+            subject.isInGroup("wheel")) {
+          return polkit.Result.YES;
+        }
+      });
+    '';
   };
   options.thoughtfull.vpn = {
     autostart = mkOption {

--- a/overlays/thoughtfull.nix
+++ b/overlays/thoughtfull.nix
@@ -207,6 +207,12 @@ in
       };
       pkgs = final;
     };
+    waybar-network = import ../packages/waybar-network.nix {
+      lib = {
+        inherit writeFileScriptBin;
+      };
+      pkgs = final;
+    };
     waybar-weather = import ../packages/waybar-weather.nix {
       lib = {
         inherit writeFileScriptBin;

--- a/packages/waybar-network.nix
+++ b/packages/waybar-network.nix
@@ -1,0 +1,86 @@
+{ lib, pkgs, ... }:
+let
+  inherit (pkgs)
+    bash
+    gawk
+    jq
+    networkmanager
+    symlinkJoin
+    systemd
+    ;
+  inherit (lib) writeFileScriptBin;
+  network-device = writeFileScriptBin {
+    name = "waybar-network-device";
+    replacements = {
+      awk = "${gawk}/bin/awk";
+      bash = "${bash}/bin/bash";
+      nmcli = "${networkmanager}/bin/nmcli";
+    };
+    src = ./waybar-network/network-device.bash;
+  };
+  waybar-network-wifi = writeFileScriptBin {
+    name = "waybar-network-wifi";
+    replacements = {
+      awk = "${gawk}/bin/awk";
+      bash = "${bash}/bin/bash";
+      jq = "${jq}/bin/jq";
+      network-device = "${network-device}/bin/waybar-network-device";
+      nmcli = "${networkmanager}/bin/nmcli";
+    };
+    src = ./waybar-network/wifi-status.bash;
+  };
+  waybar-network-wifi-toggle = writeFileScriptBin {
+    name = "waybar-network-wifi-toggle";
+    replacements = {
+      bash = "${bash}/bin/bash";
+      network-device = "${network-device}/bin/waybar-network-device";
+      nmcli = "${networkmanager}/bin/nmcli";
+    };
+    src = ./waybar-network/wifi-toggle.bash;
+  };
+  waybar-network-ethernet = writeFileScriptBin {
+    name = "waybar-network-ethernet";
+    replacements = {
+      bash = "${bash}/bin/bash";
+      network-device = "${network-device}/bin/waybar-network-device";
+    };
+    src = ./waybar-network/ethernet-status.bash;
+  };
+  waybar-network-ethernet-toggle = writeFileScriptBin {
+    name = "waybar-network-ethernet-toggle";
+    replacements = {
+      bash = "${bash}/bin/bash";
+      network-device = "${network-device}/bin/waybar-network-device";
+      nmcli = "${networkmanager}/bin/nmcli";
+    };
+    src = ./waybar-network/ethernet-toggle.bash;
+  };
+  waybar-network-vpn = writeFileScriptBin {
+    name = "waybar-network-vpn";
+    replacements = {
+      bash = "${bash}/bin/bash";
+      systemctl = "${systemd}/bin/systemctl";
+    };
+    src = ./waybar-network/vpn-status.bash;
+  };
+  waybar-network-vpn-toggle = writeFileScriptBin {
+    name = "waybar-network-vpn-toggle";
+    replacements = {
+      bash = "${bash}/bin/bash";
+      systemctl = "${systemd}/bin/systemctl";
+    };
+    src = ./waybar-network/vpn-toggle.bash;
+  };
+in
+symlinkJoin {
+  name = "waybar-network";
+  paths = [
+    network-device
+    waybar-network-ethernet
+    waybar-network-ethernet-toggle
+    waybar-network-vpn
+    waybar-network-vpn-toggle
+    waybar-network-wifi
+    waybar-network-wifi-toggle
+  ];
+}

--- a/packages/waybar-network/ethernet-status.bash
+++ b/packages/waybar-network/ethernet-status.bash
@@ -1,0 +1,23 @@
+#!@bash@
+set -euo pipefail
+
+# Reports Ethernet connection state for the Waybar custom/network-ethernet
+# widget. Device discovery is shared with ethernet-toggle.bash via
+# network-device (see that script for why).
+mapfile -t fields < <(@network-device@ ethernet)
+dev="${fields[0]:-}"
+state="${fields[1]:-}"
+
+if [[ -z ${dev} ]]; then
+  printf '{"text": "󰈀", "tooltip": "No Ethernet device", "class": "disabled"}\n'
+  exit 0
+fi
+
+# NetworkManager reports states like "connected" but also suffixed variants
+# such as "connected (externally)" for devices it didn't activate itself, so
+# match on the prefix rather than exact equality.
+if [[ ${state} == connected* ]]; then
+  printf '{"text": "󰈀", "tooltip": "Ethernet connected\\nClick to disconnect", "class": "connected"}\n'
+else
+  printf '{"text": "󰈀", "tooltip": "Ethernet disconnected\\nClick to reconnect", "class": "disconnected"}\n'
+fi

--- a/packages/waybar-network/ethernet-toggle.bash
+++ b/packages/waybar-network/ethernet-toggle.bash
@@ -1,0 +1,14 @@
+#!@bash@
+set -euo pipefail
+
+# Toggles the Ethernet device found by network-device.
+mapfile -t fields < <(@network-device@ ethernet)
+dev="${fields[0]:-}"
+state="${fields[1]:-}"
+[[ -z ${dev} ]] && exit 0
+
+if [[ ${state} == connected* ]]; then
+  @nmcli@ device disconnect "${dev}"
+else
+  @nmcli@ device connect "${dev}"
+fi

--- a/packages/waybar-network/network-device.bash
+++ b/packages/waybar-network/network-device.bash
@@ -1,0 +1,13 @@
+#!@bash@
+set -euo pipefail
+
+# Prints the first device of the given nmcli TYPE ("wifi" or "ethernet") and
+# its state, one per line, or nothing if no such device exists (or
+# NetworkManager is unreachable). Shared by the wifi/ethernet status and
+# toggle scripts so device-discovery logic only lives in one place --
+# packages/theme-toggle.nix's theme-get is the precedent for this
+# status/toggle shared-helper pattern.
+type="$1"
+# shellcheck disable=SC2016
+@nmcli@ -t -f DEVICE,TYPE,STATE device status 2>/dev/null |
+  @awk@ -F: -v t="${type}" '$2==t{print $1; print $3; exit}' || true

--- a/packages/waybar-network/vpn-status.bash
+++ b/packages/waybar-network/vpn-status.bash
@@ -1,0 +1,17 @@
+#!@bash@
+set -euo pipefail
+
+# Reports connection state of the wg-quick home VPN (nixosModules/vpn.nix
+# aliases wg-quick-wg0.service to vpn.service). Querying is-active needs no
+# elevated privilege; only starting/stopping it does (see vpn-toggle.bash).
+load_state="$(@systemctl@ show --property=LoadState --value vpn.service 2>/dev/null || true)"
+if [[ ${load_state} != loaded ]]; then
+  printf '{"text": "󰦝", "tooltip": "VPN unavailable", "class": "disabled"}\n'
+  exit 0
+fi
+
+if @systemctl@ is-active --quiet vpn.service; then
+  printf '{"text": "󰦝", "tooltip": "VPN connected\\nClick to disconnect", "class": "connected"}\n'
+else
+  printf '{"text": "󰦝", "tooltip": "VPN disconnected\\nClick to connect", "class": "disconnected"}\n'
+fi

--- a/packages/waybar-network/vpn-toggle.bash
+++ b/packages/waybar-network/vpn-toggle.bash
@@ -1,0 +1,12 @@
+#!@bash@
+set -euo pipefail
+
+# Starts/stops the wg-quick home VPN. Authorized for non-root callers by the
+# polkit rule in nixosModules/vpn.nix, scoped to exactly this unit.
+[[ $(@systemctl@ show --property=LoadState --value vpn.service 2>/dev/null || true) == loaded ]] || exit 0
+
+if @systemctl@ is-active --quiet vpn.service; then
+  @systemctl@ stop vpn.service
+else
+  @systemctl@ start vpn.service
+fi

--- a/packages/waybar-network/wifi-status.bash
+++ b/packages/waybar-network/wifi-status.bash
@@ -1,0 +1,44 @@
+#!@bash@
+set -euo pipefail
+
+# Reports Wi-Fi connection state for the Waybar custom/network-wifi widget.
+# Device discovery is shared with wifi-toggle.bash via network-device (see
+# that script for why).
+mapfile -t fields < <(@network-device@ wifi)
+dev="${fields[0]:-}"
+state="${fields[1]:-}"
+
+if [[ -z ${dev} ]]; then
+  printf '{"text": "󰤯", "tooltip": "No Wi-Fi device", "class": "disabled"}\n'
+  exit 0
+fi
+
+# NetworkManager reports states like "connected" but also suffixed variants
+# such as "connected (externally)" for devices it didn't activate itself, so
+# match on the prefix rather than exact equality.
+if [[ ${state} == connected* ]]; then
+  # nmcli's terse output backslash-escapes literal colons within a field
+  # (e.g. an SSID containing ":"). Isolate the trailing numeric signal first
+  # (it can't contain a colon), then unescape the remaining SSID.
+  # shellcheck disable=SC2016
+  raw=$(@nmcli@ -t -f active,ssid,signal dev wifi 2>/dev/null | @awk@ -F: '$1=="yes"{print; exit}') || true
+  rest="${raw#yes:}"
+  signal="${rest##*:}"
+  ssid="${rest%:*}"
+  ssid="${ssid//\\:/:}"
+  icon="󰤨"
+  if [[ ${signal:-0} =~ ^[0-9]+$ ]]; then
+    if ((signal <= 25)); then
+      icon="󰤟"
+    elif ((signal <= 50)); then
+      icon="󰤢"
+    elif ((signal <= 75)); then
+      icon="󰤥"
+    fi
+  fi
+  # shellcheck disable=SC2016
+  @jq@ -cn --arg icon "${icon}" --arg ssid "${ssid}" --arg signal "${signal}" \
+    '{text: $icon, tooltip: ("Wi-Fi: " + $ssid + " (" + $signal + "%)\nClick to disconnect"), class: "connected"}'
+else
+  printf '{"text": "󰤯", "tooltip": "Wi-Fi disconnected\\nClick to reconnect, right-click to browse", "class": "disconnected"}\n'
+fi

--- a/packages/waybar-network/wifi-toggle.bash
+++ b/packages/waybar-network/wifi-toggle.bash
@@ -1,0 +1,17 @@
+#!@bash@
+set -euo pipefail
+
+# Toggles the Wi-Fi device found by network-device: disconnects it if
+# connected, otherwise turns the radio on and asks NetworkManager to
+# (re)connect using its normal best-available-connection logic.
+mapfile -t fields < <(@network-device@ wifi)
+dev="${fields[0]:-}"
+state="${fields[1]:-}"
+[[ -z ${dev} ]] && exit 0
+
+if [[ ${state} == connected* ]]; then
+  @nmcli@ device disconnect "${dev}"
+else
+  @nmcli@ radio wifi on
+  @nmcli@ device connect "${dev}"
+fi

--- a/tests.nix
+++ b/tests.nix
@@ -23,6 +23,7 @@ forEachSystem (
     monitoring = callTest ./tests/monitoring.nix;
     nixfiles = callTest ./tests/nixfiles.nix;
     system-pull = callTest ./tests/system-pull.nix;
+    vpn = callTest ./tests/vpn.nix;
     waybar = callTest ./tests/waybar.nix;
   }
 )

--- a/tests/graphical.nix
+++ b/tests/graphical.nix
@@ -53,7 +53,7 @@ nixpkgs.testers.nixosTest {
 
   nodes = {
     enabled =
-      { lib, ... }:
+      { config, lib, ... }:
       {
         inherit imports;
         thoughtfull.graphical.enable = true;
@@ -63,6 +63,9 @@ nixpkgs.testers.nixosTest {
         programs.sway.enable = lib.mkForce false;
         services.emacs.enable = lib.mkForce false;
         services.syncthing.enable = lib.mkForce false;
+        environment.etc."thoughtfull-user-extra-groups".text =
+          builtins.concatStringsSep "\n" config.thoughtfull.user.extraGroups;
+        environment.etc."networkmanager-wifi-backend".text = config.networking.networkmanager.wifi.backend;
       };
 
     disabled = {
@@ -78,6 +81,13 @@ nixpkgs.testers.nixosTest {
 
     with subtest("graphical enabled: NetworkManager is configured"):
         enabled.succeed("systemctl cat NetworkManager.service")
+
+    with subtest("graphical enabled: user can control NetworkManager"):
+        enabled.succeed("grep -Fx networkmanager /etc/thoughtfull-user-extra-groups")
+
+    with subtest("graphical enabled: iwmenu backend is configured"):
+        enabled.succeed("systemctl cat iwd.service")
+        enabled.succeed("grep -Fx iwd /etc/networkmanager-wifi-backend")
 
     with subtest("graphical disabled: NetworkManager is not configured"):
         disabled.fail("systemctl cat NetworkManager.service")

--- a/tests/vpn.nix
+++ b/tests/vpn.nix
@@ -1,0 +1,109 @@
+{ nixpkgs, ... }:
+let
+  # Stub the agenix `age.secrets` option so we can test vpn.nix's polkit
+  # wiring without pulling in real agenix activation scripts (which need a
+  # real SSH identity to decrypt).
+  ageSecretsStub =
+    { lib, ... }:
+    {
+      options.age.secrets = lib.mkOption {
+        default = { };
+        type = lib.types.attrsOf (
+          lib.types.submodule (
+            { name, ... }:
+            {
+              options = {
+                file = lib.mkOption { type = lib.types.path; };
+                mode = lib.mkOption {
+                  type = lib.types.str;
+                  default = "0400";
+                };
+                path = lib.mkOption {
+                  type = lib.types.str;
+                  default = "/run/agenix/${name}";
+                };
+              };
+            }
+          )
+        );
+      };
+    };
+in
+nixpkgs.testers.nixosTest {
+  name = "vpn";
+
+  skipTypeCheck = true;
+  skipLint = true;
+
+  nodes = {
+    enabled =
+      { lib, pkgs, ... }:
+      {
+        imports = [
+          ../nixosModules/vpn.nix
+          ageSecretsStub
+        ];
+        # Use a fake plaintext file instead of a real .age fixture so the
+        # test doesn't depend on the encrypted secret being decryptable.
+        thoughtfull.vpn.configFile = pkgs.writeText "fake-wg-config" "fake";
+
+        # Swap the real wg-quick invocation for a harmless no-op, keeping
+        # vpn.nix's own unit name/alias/polkit rule wiring untouched, so the
+        # authorization test below doesn't need real WireGuard key material.
+        systemd.services.wg-quick-wg0.serviceConfig = lib.mkForce {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          ExecStart = "${pkgs.coreutils}/bin/true";
+          ExecStop = "${pkgs.coreutils}/bin/true";
+        };
+
+        users.users.wheeluser = {
+          isNormalUser = true;
+          extraGroups = [ "wheel" ];
+        };
+      };
+
+    disabled = {
+      imports = [
+        ../nixosModules/vpn.nix
+        ageSecretsStub
+      ];
+      thoughtfull.vpn.configFile = null;
+    };
+  };
+
+  testScript = ''
+    start_all()
+    enabled.wait_for_unit("multi-user.target")
+    disabled.wait_for_unit("multi-user.target")
+
+    with subtest("vpn enabled: polkit rule authorizes toggling wg-quick-wg0.service for wheel"):
+        rules = enabled.succeed("cat /etc/polkit-1/rules.d/10-nixos.rules")
+        assert "org.freedesktop.systemd1.manage-units" in rules, (
+            "polkit rule should authorize the systemd manage-units action"
+        )
+        assert "wg-quick-wg0.service" in rules, (
+            "polkit rule should be scoped to the wg-quick-wg0 unit"
+        )
+        assert "vpn.service" in rules, "polkit rule should authorize the vpn.service alias"
+        assert "wheel" in rules, "polkit rule should be scoped to the wheel group"
+
+    with subtest("vpn disabled: no polkit rule is rendered"):
+        disabled.fail("test -f /etc/polkit-1/rules.d/10-nixos.rules")
+
+    with subtest("vpn enabled: a non-root wheel user can start/stop the VPN via its alias"):
+        # Exercises the real mechanism waybar-network-vpn-toggle relies on:
+        # a non-root wheel user calling `systemctl {start,stop} vpn.service`
+        # (the alias), authorized by the polkit rule above which matches on
+        # the canonical unit id (wg-quick-wg0.service). Not just a rule-text
+        # grep -- this confirms systemd resolves the alias to the canonical
+        # unit before polkit's action.lookup("unit") check runs.
+        enabled.succeed("systemctl stop vpn.service || true")
+
+        enabled.succeed("su wheeluser -c 'systemctl start vpn.service'")
+        enabled.succeed("systemctl is-active --quiet vpn.service")
+
+        enabled.succeed("su wheeluser -c 'systemctl stop vpn.service'")
+        enabled.fail("systemctl is-active --quiet vpn.service")
+  '';
+}

--- a/tests/waybar.nix
+++ b/tests/waybar.nix
@@ -77,11 +77,31 @@ testPkgs.testers.nixosTest {
           after = [ "cycle-canary-a.service" ];
           serviceConfig.ExecStart = "${pkgs.coreutils}/bin/true";
         };
+
+        # Stub for the custom/network-vpn widget. Exercises the real
+        # waybar-network-vpn/-toggle scripts against a real systemd unit
+        # instead of the real wg-quick wiring (this focused test doesn't
+        # import vpn.nix); polkit authorization for a non-root caller is
+        # covered separately in tests/vpn.nix.
+        systemd.services.vpn = {
+          description = "Stub VPN service for waybar-network-vpn tests";
+          serviceConfig.ExecStart = "${pkgs.coreutils}/bin/sleep infinity";
+        };
+      };
+
+    noVpn =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = [ pkgs.thoughtfull.waybar-network ];
       };
   };
 
   testScript = ''
+    import json
+
+    start_all()
     machine.wait_for_unit("multi-user.target")
+    noVpn.wait_for_unit("multi-user.target")
 
     with subtest("yubikey-touch-detector service exists"):
         # Check that yubikey-touch-detector service file exists
@@ -282,5 +302,151 @@ testPkgs.testers.nixosTest {
         assert "sway-session.target" in pasystray_unit, (
             "pasystray should be ordered After=sway-session.target"
         )
+
+    with subtest("nm-applet is removed"):
+        machine.fail("test -f /etc/systemd/user/nm-applet.service")
+
+    with subtest("waybar config wires up the network widgets"):
+        # Replaces nm-applet's tray icon with three custom modules: Wi-Fi,
+        # Ethernet, and the wg-quick home VPN.
+        config = machine.succeed("cat /etc/xdg/waybar/config.jsonc")
+        for module in ["custom/network-wifi", "custom/network-ethernet", "custom/network-vpn"]:
+            assert f'"{module}"' in config, f"{module} missing from config.jsonc"
+
+        # Placed after battery, before tray -- the slot the old nm-applet
+        # tray icon occupied.
+        assert (
+            config.index('"battery"')
+            < config.index('"custom/network-wifi"')
+            < config.index('"tray"')
+        ), "network widgets should sit between battery and tray"
+
+        for module in ["custom/network-wifi", "custom/network-ethernet", "custom/network-vpn"]:
+            block = config[config.index(f'"{module}": {{') :]
+            block = block[: block.index("\n  },")]
+            assert '"format": "<span font=\\"20px\\">{}</span>"' in block, (
+                f"{module} should use the same 20px icon format as theme/power"
+            )
+
+        machine.succeed('grep -q \'"exec": "waybar-network-wifi"\' /etc/xdg/waybar/config.jsonc')
+        machine.succeed(
+            'grep -q \'"on-click": "iwmenu --launcher fuzzel"\' /etc/xdg/waybar/config.jsonc'
+        )
+        machine.succeed(
+            'grep -q \'"on-click-middle": "waybar-network-wifi-toggle"\' /etc/xdg/waybar/config.jsonc'
+        )
+        machine.succeed(
+            'grep -q \'"on-click-right": "waybar-network-wifi-toggle"\' /etc/xdg/waybar/config.jsonc'
+        )
+        machine.succeed('grep -q \'"exec": "waybar-network-ethernet"\' /etc/xdg/waybar/config.jsonc')
+        machine.succeed(
+            'grep -q \'"on-click": "waybar-network-ethernet-toggle"\' /etc/xdg/waybar/config.jsonc'
+        )
+        machine.succeed(
+            'grep -q \'"on-click-middle": "waybar-network-ethernet-toggle"\' /etc/xdg/waybar/config.jsonc'
+        )
+        machine.succeed(
+            'grep -q \'"on-click-right": "nm-connection-editor -t 802-3-ethernet -s"\' /etc/xdg/waybar/config.jsonc'
+        )
+        machine.succeed('grep -q \'"exec": "waybar-network-vpn"\' /etc/xdg/waybar/config.jsonc')
+        machine.succeed(
+            'grep -q \'"on-click": "waybar-network-vpn-toggle"\' /etc/xdg/waybar/config.jsonc'
+        )
+        machine.succeed(
+            'grep -q \'"on-click-middle": "waybar-network-vpn-toggle"\' /etc/xdg/waybar/config.jsonc'
+        )
+        machine.succeed(
+            'grep -q \'"on-click-right": "waybar-network-vpn-toggle"\' /etc/xdg/waybar/config.jsonc'
+        )
+
+    with subtest("waybar service PATH provides the network widgets' tooling"):
+        # PATH= only lists directories (nix store paths), one per package --
+        # individual binary names inside a symlinkJoin bundle (like the six
+        # waybar-network-* scripts, all joined under one "waybar-network"
+        # output) don't appear literally, only the bundle's own name does.
+        dropin = machine.succeed("cat /etc/systemd/user/waybar.service.d/*.conf")
+        for tool in [
+            "fuzzel",
+            "iwmenu",
+            "networkmanager",
+            "network-manager-applet",
+            "procps",
+            "waybar-network",
+        ]:
+            assert tool in dropin, f"{tool} missing from waybar PATH"
+
+    with subtest("network widgets use icon padding and no active background"):
+        style = machine.succeed("cat /etc/xdg/waybar/style.css")
+        assert (
+            "#custom-network-wifi {\n  padding: 0 12pt 0 6pt;\n}"
+            in style
+        ), "Wi-Fi should use display-like right padding"
+        assert (
+            "#custom-network-ethernet,\n#custom-network-vpn,\n#mode"
+            in style
+        ), "Ethernet should use the default network widget padding"
+        assert "#custom-network-ethernet {" not in style, (
+            "Ethernet should use the default network widget padding"
+        )
+        assert "#custom-network-ethernet.connected" not in style, (
+            "Ethernet should use the normal background when connected"
+        )
+        assert "#custom-network-vpn.connected" not in style, (
+            "VPN should use the normal background when connected"
+        )
+
+    with subtest("waybar-network-wifi reports a disabled state when NetworkManager is unavailable"):
+        # This test node doesn't enable networking.networkmanager, so nmcli
+        # has no daemon to talk to -- the widget should degrade gracefully
+        # rather than crash waybar's exec loop.
+        out = machine.succeed("waybar-network-wifi").strip()
+        print(f"waybar-network-wifi output: {out}")
+        status = json.loads(out)
+        assert status["class"] == "disabled", f"expected a disabled state, got: {out}"
+        assert status["text"] == "󰤯", f"expected icon-only Wi-Fi text, got: {out}"
+
+        waybar_network_dir = machine.succeed(
+            "dirname $(readlink -f $(command -v waybar-network-wifi))"
+        ).strip()
+        for icon in ["󰤟", "󰤢", "󰤥", "󰤨"]:
+            machine.succeed(f"grep -R -q '{icon}' {waybar_network_dir}")
+
+    with subtest(
+        "waybar-network-ethernet reports a disabled state when NetworkManager is unavailable"
+    ):
+        out = machine.succeed("waybar-network-ethernet").strip()
+        print(f"waybar-network-ethernet output: {out}")
+        status = json.loads(out)
+        assert status["class"] == "disabled", f"expected a disabled state, got: {out}"
+        assert status["text"] == "󰈀", f"expected icon-only Ethernet text, got: {out}"
+
+    with subtest("waybar-network-vpn is disabled when vpn.service is absent"):
+        out = noVpn.succeed("waybar-network-vpn").strip()
+        status = json.loads(out)
+        assert status["class"] == "disabled", f"expected disabled, got: {out}"
+        assert status["text"] == "󰦝", f"expected icon-only VPN text, got: {out}"
+        noVpn.succeed("waybar-network-vpn-toggle")
+
+    with subtest("waybar-network-vpn reflects and toggles a real systemd unit"):
+        machine.succeed("systemctl stop vpn.service || true")
+
+        out = machine.succeed("waybar-network-vpn").strip()
+        status = json.loads(out)
+        assert status["class"] == "disconnected", f"expected disconnected, got: {out}"
+        assert status["text"] == "󰦝", f"expected icon-only VPN text, got: {out}"
+
+        machine.succeed("waybar-network-vpn-toggle")
+        machine.succeed("systemctl is-active --quiet vpn.service")
+        out = machine.succeed("waybar-network-vpn").strip()
+        status = json.loads(out)
+        assert status["class"] == "connected", f"expected connected, got: {out}"
+        assert status["text"] == "󰦝", f"expected icon-only VPN text, got: {out}"
+
+        machine.succeed("waybar-network-vpn-toggle")
+        machine.fail("systemctl is-active --quiet vpn.service")
+        out = machine.succeed("waybar-network-vpn").strip()
+        status = json.loads(out)
+        assert status["class"] == "disconnected", f"expected disconnected again, got: {out}"
+        assert status["text"] == "󰦝", f"expected icon-only VPN text, got: {out}"
   '';
 }

--- a/tests/waybar.nix
+++ b/tests/waybar.nix
@@ -370,7 +370,6 @@ testPkgs.testers.nixosTest {
             "iwmenu",
             "networkmanager",
             "network-manager-applet",
-            "procps",
             "waybar-network",
         ]:
             assert tool in dropin, f"{tool} missing from waybar PATH"


### PR DESCRIPTION
Summary:
- Replace nm-applet with Waybar Wi-Fi, Ethernet, and VPN widgets.
- Add waybar-network scripts for status and toggles.
- Configure iwd/NetworkManager defaults needed by iwmenu and add scoped VPN polkit authorization.
- Add tests covering graphical defaults, Waybar wiring, and VPN authorization.

Verification:
- devenv tasks run devenv:git-hooks:run
- nix build .#checks.x86_64-linux.waybar
- nix build .#checks.x86_64-linux.graphical
- nix build .#checks.x86_64-linux.vpn
- nix build .#nixosConfigurations.hydor.config.system.build.toplevel --no-link