### PR TITLE
Persist devenv share directory

### DIFF
--- a/nixosModules/dev.nix
+++ b/nixosModules/dev.nix
@@ -32,6 +32,7 @@ in
     thoughtfull.impermanence.user = {
       directories = [
         ".config/gh"
+        ".local/share/devenv"
       ]
       ++ (optionals claude.enable [ ".claude" ])
       ++ (optionals opencode.enable [


### PR DESCRIPTION
## Summary
- devenv stores cached build state under `~/.local/share/devenv`; add it to the impermanence persisted directories list so it survives reboots on impermanent systems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)