### PR TITLE
Add role-duration-seconds input to configure-nix-daemon-aws-creds

### DIFF
--- a/.github/actions/configure-nix-daemon-aws-creds/action.yml
+++ b/.github/actions/configure-nix-daemon-aws-creds/action.yml
@@ -12,6 +12,9 @@ inputs:
   aws-region:
     description: AWS region to assume the role in.
     default: us-east-1
+  role-duration-seconds:
+    description: Duration, in seconds, of the assumed role's temporary credentials.
+    default: 3600
 runs:
   using: composite
   steps:
@@ -19,6 +22,7 @@ runs:
       uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
+        role-duration-seconds: ${{ inputs.role-duration-seconds }}
         aws-region: ${{ inputs.aws-region }}
         aws-profile: default
         overwrite-aws-profile: true

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -48,9 +48,18 @@ jobs:
             extra-substituters = s3://thoughtfull-nix-cache?region=us-east-1 https://cache.numtide.com https://devenv.cachix.org
             extra-trusted-public-keys = nix-cache.thoughtfull.systems-1:kN4M+h0QLcDpQksBsFNtE9t6+bLa/s4axEWYpDmz2ag= niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g= devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
       - name: Configure Nix daemon AWS credentials
+        if: matrix.runner != 'ubuntu-24.04-arm'
         uses: ./.github/actions/configure-nix-daemon-aws-creds
         with:
           role-to-assume: arn:aws:iam::481411455398:role/NixCacheWriter
+      - name: Configure Nix daemon AWS credentials (arm)
+        # The arm runner is slower, so give its assumed role's credentials
+        # longer to live than the default before they expire mid-build.
+        if: matrix.runner == 'ubuntu-24.04-arm'
+        uses: ./.github/actions/configure-nix-daemon-aws-creds
+        with:
+          role-to-assume: arn:aws:iam::481411455398:role/NixCacheWriter
+          role-duration-seconds: 7200
       - name: Build system closures
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- Adds an optional `role-duration-seconds` input to the `configure-nix-daemon-aws-creds` action, passed through to `aws-actions/configure-aws-credentials`, defaulting to 3600 seconds.
- The arm build in `build-and-push.yml` now passes 7200 seconds since it's slower and needs credentials to live longer than the default.