### PR TITLE
Fix Wi-Fi: give iwd sole ownership, keep NetworkManager for ethernet

### DIFF
--- a/nixosModules/graphical.nix
+++ b/nixosModules/graphical.nix
@@ -5,7 +5,12 @@
 }:
 let
   inherit (config.thoughtfull) graphical;
-  inherit (lib) mkDefault mkEnableOption mkIf;
+  inherit (lib)
+    mkDefault
+    mkEnableOption
+    mkForce
+    mkIf
+    ;
 in
 {
   config = mkIf graphical.enable {
@@ -14,9 +19,51 @@ in
     networking = {
       networkmanager = {
         enable = mkDefault true;
-        wifi.backend = mkDefault "iwd";
+        # Wi-Fi is managed by iwd directly (iwmenu talks to iwd's D-Bus API,
+        # bypassing NetworkManager) -- NetworkManager managing the same
+        # device at the same time caused the two to race and repeatedly
+        # fail to connect. NetworkManager still manages ethernet.
+        #
+        # This can't be mkDefault: nixpkgs' netbird module unconditionally
+        # sets this (at normal priority, even when netbird is disabled) to
+        # the netbird client interfaces, which is `[]` here since netbird
+        # isn't used. listOf options merge by concatenating all definitions
+        # at the winning priority tier, so a normal-priority `[]` from
+        # netbird beats and discards an mkDefault entirely -- a plain
+        # assignment here instead joins that tier, concatenating with it.
+        unmanaged = [ "type:wifi" ];
       };
-      wireless.iwd.enable = mkDefault true;
+      # NetworkManager's module wants to enable this wpa_supplicant service
+      # itself whenever its own wifi.backend isn't "iwd" (the default is
+      # "wpa_supplicant"), which conflicts with wireless.iwd.enable below.
+      # Deliberately not setting wifi.backend = "iwd" to avoid that: doing
+      # so makes NetworkManager instantiate its own iwd manager (for every
+      # iwd-backed interface it discovers, managed or not) which registers
+      # itself as iwd's network-configuration D-Bus agent -- and then
+      # rejects iwd's own DHCP requests for this unmanaged device with
+      # "InvalidConnection", since NetworkManager never actually activates
+      # it. iwd doesn't need NetworkManager involved in any way here.
+      wireless.enable = mkForce false;
+      wireless.iwd = {
+        enable = mkDefault true;
+        settings = {
+          # NetworkManager no longer configures IP addresses for Wi-Fi
+          # devices, so iwd has to do it itself.
+          General.EnableNetworkConfiguration = mkDefault true;
+          # Without this, sometimes wlan0 simply goes AWOL:
+          # https://iwd.wiki.kernel.org/interface_lifecycle#interface_management_in_iwd
+          # Normally NetworkManager's iwd backend sets this automatically,
+          # but Wi-Fi is unmanaged by NetworkManager here, so it doesn't.
+          DriverQuirks.DefaultInterface = mkDefault "?*";
+          # iwd's own default (systemd, i.e. systemd-resolved) assumes
+          # systemd-resolved is running. It isn't -- DNS here is managed
+          # the classic way, via resolvconf (see NetworkManager's rc-manager
+          # above, which uses it for ethernet already) -- so without this,
+          # Wi-Fi connects and gets an IP but /etc/resolv.conf never gets a
+          # nameserver for it.
+          Network.NameResolvingService = mkDefault "resolvconf";
+        };
+      };
     };
     programs = {
       firefox.enable = mkDefault true;

--- a/nixosModules/graphical.nix
+++ b/nixosModules/graphical.nix
@@ -56,11 +56,11 @@ in
           # but Wi-Fi is unmanaged by NetworkManager here, so it doesn't.
           DriverQuirks.DefaultInterface = mkDefault "?*";
           # iwd's own default (systemd, i.e. systemd-resolved) assumes
-          # systemd-resolved is running. It isn't -- DNS here is managed
-          # the classic way, via resolvconf (see NetworkManager's rc-manager
-          # above, which uses it for ethernet already) -- so without this,
-          # Wi-Fi connects and gets an IP but /etc/resolv.conf never gets a
-          # nameserver for it.
+          # systemd-resolved is running. It isn't: this system resolves
+          # DNS the classic way, via the resolvconf program (which is also
+          # what NetworkManager uses for ethernet, by nixpkgs' default) --
+          # so without this, Wi-Fi connects and gets an IP but
+          # /etc/resolv.conf never gets a nameserver for it.
           Network.NameResolvingService = mkDefault "resolvconf";
         };
       };

--- a/nixosModules/impermanence.nix
+++ b/nixosModules/impermanence.nix
@@ -22,6 +22,7 @@ in
       hideMounts = mkDefault true;
       directories = [
         "/etc/NetworkManager/system-connections"
+        "/var/lib/iwd"
         "/var/lib/nixos"
         "/var/lib/systemd/backlight"
         "/var/lib/systemd/coredump"

--- a/packages/waybar-network.nix
+++ b/packages/waybar-network.nix
@@ -18,14 +18,21 @@ let
     };
     src = ./waybar-network/network-device.bash;
   };
+  wifi-device = writeFileScriptBin {
+    name = "waybar-network-wifi-device";
+    replacements = {
+      bash = "${bash}/bin/bash";
+      busctl = "${systemd}/bin/busctl";
+      jq = "${jq}/bin/jq";
+    };
+    src = ./waybar-network/wifi-device.bash;
+  };
   waybar-network-wifi = writeFileScriptBin {
     name = "waybar-network-wifi";
     replacements = {
-      awk = "${gawk}/bin/awk";
       bash = "${bash}/bin/bash";
       jq = "${jq}/bin/jq";
-      network-device = "${network-device}/bin/waybar-network-device";
-      nmcli = "${networkmanager}/bin/nmcli";
+      wifi-device = "${wifi-device}/bin/waybar-network-wifi-device";
     };
     src = ./waybar-network/wifi-status.bash;
   };
@@ -33,8 +40,9 @@ let
     name = "waybar-network-wifi-toggle";
     replacements = {
       bash = "${bash}/bin/bash";
-      network-device = "${network-device}/bin/waybar-network-device";
-      nmcli = "${networkmanager}/bin/nmcli";
+      busctl = "${systemd}/bin/busctl";
+      jq = "${jq}/bin/jq";
+      wifi-device = "${wifi-device}/bin/waybar-network-wifi-device";
     };
     src = ./waybar-network/wifi-toggle.bash;
   };
@@ -82,5 +90,6 @@ symlinkJoin {
     waybar-network-vpn-toggle
     waybar-network-wifi
     waybar-network-wifi-toggle
+    wifi-device
   ];
 }

--- a/packages/waybar-network/wifi-device.bash
+++ b/packages/waybar-network/wifi-device.bash
@@ -1,0 +1,38 @@
+#!@bash@
+set -euo pipefail
+
+# Prints the iwd station device's object path, powered state ("on"/"off"),
+# station state, connected SSID, and (while connected) RSSI in dBm -- one
+# per line -- or nothing if no wifi device exists (or iwd is unreachable).
+# Wifi is owned directly by iwd rather than NetworkManager (see
+# graphical.nix), so this queries iwd's D-Bus objects instead of nmcli,
+# which network-device.bash uses for the NetworkManager-managed ethernet
+# device. Shared by wifi-status.bash and wifi-toggle.bash so this discovery
+# logic only lives in one place -- same reasoning as network-device.bash.
+objects=$(@busctl@ --system -j call net.connman.iwd / org.freedesktop.DBus.ObjectManager GetManagedObjects 2>/dev/null) || exit 0
+
+# shellcheck disable=SC2016
+parsed=$(@jq@ -r '
+  .data[0] as $objs
+  | ($objs | to_entries[] | select(.value["net.connman.iwd.Device"].Mode.data? == "station")) as $d
+  | ($d.value["net.connman.iwd.Station"].ConnectedNetwork.data // "") as $net
+  | [
+      $d.key,
+      ($d.value["net.connman.iwd.Device"].Powered.data | if . then "on" else "off" end),
+      ($d.value["net.connman.iwd.Station"].State.data // "disconnected"),
+      (if $net != "" then $objs[$net]["net.connman.iwd.Network"].Name.data else "" end)
+    ] | @tsv
+' <<<"${objects}" 2>/dev/null) || exit 0
+[[ -z ${parsed} ]] && exit 0
+
+IFS=$'\t' read -r dev powered state ssid <<<"${parsed}"
+
+rssi=""
+if [[ ${state} == "connected" ]]; then
+  rssi=$(
+    @busctl@ --system -j call net.connman.iwd "${dev}" net.connman.iwd.StationDiagnostic GetDiagnostics 2>/dev/null |
+      @jq@ -r '.data[0].RSSI.data // empty' 2>/dev/null
+  ) || rssi=""
+fi
+
+printf '%s\n' "${dev}" "${powered}" "${state}" "${ssid}" "${rssi}"

--- a/packages/waybar-network/wifi-device.bash
+++ b/packages/waybar-network/wifi-device.bash
@@ -1,14 +1,14 @@
 #!@bash@
 set -euo pipefail
 
-# Prints the iwd station device's object path, powered state ("on"/"off"),
-# station state, connected SSID, and (while connected) RSSI in dBm -- one
-# per line -- or nothing if no wifi device exists (or iwd is unreachable).
-# Wifi is owned directly by iwd rather than NetworkManager (see
-# graphical.nix), so this queries iwd's D-Bus objects instead of nmcli,
-# which network-device.bash uses for the NetworkManager-managed ethernet
-# device. Shared by wifi-status.bash and wifi-toggle.bash so this discovery
-# logic only lives in one place -- same reasoning as network-device.bash.
+# Prints the iwd station device's object path, station state, connected
+# SSID, and (while connected) RSSI in dBm -- one per line -- or nothing if
+# no wifi device exists (or iwd is unreachable). Wifi is owned directly by
+# iwd rather than NetworkManager (see graphical.nix), so this queries
+# iwd's D-Bus objects instead of nmcli, which network-device.bash uses for
+# the NetworkManager-managed ethernet device. Shared by wifi-status.bash
+# and wifi-toggle.bash so this discovery logic only lives in one place --
+# same reasoning as network-device.bash.
 objects=$(@busctl@ --system -j call net.connman.iwd / org.freedesktop.DBus.ObjectManager GetManagedObjects 2>/dev/null) || exit 0
 
 # shellcheck disable=SC2016
@@ -18,14 +18,13 @@ parsed=$(@jq@ -r '
   | ($d.value["net.connman.iwd.Station"].ConnectedNetwork.data // "") as $net
   | [
       $d.key,
-      ($d.value["net.connman.iwd.Device"].Powered.data | if . then "on" else "off" end),
       ($d.value["net.connman.iwd.Station"].State.data // "disconnected"),
       (if $net != "" then $objs[$net]["net.connman.iwd.Network"].Name.data else "" end)
     ] | @tsv
 ' <<<"${objects}" 2>/dev/null) || exit 0
 [[ -z ${parsed} ]] && exit 0
 
-IFS=$'\t' read -r dev powered state ssid <<<"${parsed}"
+IFS=$'\t' read -r dev state ssid <<<"${parsed}"
 
 rssi=""
 if [[ ${state} == "connected" ]]; then
@@ -35,4 +34,4 @@ if [[ ${state} == "connected" ]]; then
   ) || rssi=""
 fi
 
-printf '%s\n' "${dev}" "${powered}" "${state}" "${ssid}" "${rssi}"
+printf '%s\n' "${dev}" "${state}" "${ssid}" "${rssi}"

--- a/packages/waybar-network/wifi-status.bash
+++ b/packages/waybar-network/wifi-status.bash
@@ -2,43 +2,35 @@
 set -euo pipefail
 
 # Reports Wi-Fi connection state for the Waybar custom/network-wifi widget.
-# Device discovery is shared with wifi-toggle.bash via network-device (see
-# that script for why).
-mapfile -t fields < <(@network-device@ wifi)
+# Device discovery is shared with wifi-toggle.bash via wifi-device (see
+# that script for why wifi uses iwd directly instead of NetworkManager).
+mapfile -t fields < <(@wifi-device@)
 dev="${fields[0]:-}"
-state="${fields[1]:-}"
+state="${fields[2]:-}"
+ssid="${fields[3]:-}"
+rssi="${fields[4]:-}"
 
 if [[ -z ${dev} ]]; then
   printf '{"text": "󰤯", "tooltip": "No Wi-Fi device", "class": "disabled"}\n'
   exit 0
 fi
 
-# NetworkManager reports states like "connected" but also suffixed variants
-# such as "connected (externally)" for devices it didn't activate itself, so
-# match on the prefix rather than exact equality.
-if [[ ${state} == connected* ]]; then
-  # nmcli's terse output backslash-escapes literal colons within a field
-  # (e.g. an SSID containing ":"). Isolate the trailing numeric signal first
-  # (it can't contain a colon), then unescape the remaining SSID.
-  # shellcheck disable=SC2016
-  raw=$(@nmcli@ -t -f active,ssid,signal dev wifi 2>/dev/null | @awk@ -F: '$1=="yes"{print; exit}') || true
-  rest="${raw#yes:}"
-  signal="${rest##*:}"
-  ssid="${rest%:*}"
-  ssid="${ssid//\\:/:}"
+if [[ ${state} == "connected" ]]; then
+  # RSSI thresholds follow the common 4-bar convention (excellent >= -50
+  # dBm, good >= -60, fair >= -70, weak below that).
   icon="󰤨"
-  if [[ ${signal:-0} =~ ^[0-9]+$ ]]; then
-    if ((signal <= 25)); then
+  if [[ ${rssi} =~ ^-?[0-9]+$ ]]; then
+    if ((rssi < -70)); then
       icon="󰤟"
-    elif ((signal <= 50)); then
+    elif ((rssi < -60)); then
       icon="󰤢"
-    elif ((signal <= 75)); then
+    elif ((rssi < -50)); then
       icon="󰤥"
     fi
   fi
   # shellcheck disable=SC2016
-  @jq@ -cn --arg icon "${icon}" --arg ssid "${ssid}" --arg signal "${signal}" \
-    '{text: $icon, tooltip: ("Wi-Fi: " + $ssid + " (" + $signal + "%)\nClick to browse networks\nRight-click to disconnect"), class: "connected"}'
+  @jq@ -cn --arg icon "${icon}" --arg ssid "${ssid}" --arg rssi "${rssi}" \
+    '{text: $icon, tooltip: ("Wi-Fi: " + $ssid + " (" + $rssi + " dBm)\nClick to browse networks\nRight-click to disconnect"), class: "connected"}'
 else
   printf '{"text": "󰤯", "tooltip": "Wi-Fi disconnected\\nClick to browse networks\\nRight-click to reconnect", "class": "disconnected"}\n'
 fi

--- a/packages/waybar-network/wifi-status.bash
+++ b/packages/waybar-network/wifi-status.bash
@@ -6,9 +6,9 @@ set -euo pipefail
 # that script for why wifi uses iwd directly instead of NetworkManager).
 mapfile -t fields < <(@wifi-device@)
 dev="${fields[0]:-}"
-state="${fields[2]:-}"
-ssid="${fields[3]:-}"
-rssi="${fields[4]:-}"
+state="${fields[1]:-}"
+ssid="${fields[2]:-}"
+rssi="${fields[3]:-}"
 
 if [[ -z ${dev} ]]; then
   printf '{"text": "󰤯", "tooltip": "No Wi-Fi device", "class": "disabled"}\n'

--- a/packages/waybar-network/wifi-toggle.bash
+++ b/packages/waybar-network/wifi-toggle.bash
@@ -1,17 +1,42 @@
 #!@bash@
 set -euo pipefail
 
-# Toggles the Wi-Fi device found by network-device: disconnects it if
-# connected, otherwise turns the radio on and asks NetworkManager to
-# (re)connect using its normal best-available-connection logic.
-mapfile -t fields < <(@network-device@ wifi)
+# Toggles the Wi-Fi device found by wifi-device: disconnects it if
+# connected, otherwise connects to the best-signal known network in range --
+# the iwd equivalent of nmcli's best-available-connection reconnect. iwd
+# doesn't autoconnect just because the radio is powered on (an explicit
+# Disconnect suppresses it), so this has to pick and connect explicitly
+# rather than relying on iwd's own autoconnect state machine.
+mapfile -t fields < <(@wifi-device@)
 dev="${fields[0]:-}"
-state="${fields[1]:-}"
+state="${fields[2]:-}"
 [[ -z ${dev} ]] && exit 0
 
-if [[ ${state} == connected* ]]; then
-  @nmcli@ device disconnect "${dev}"
-else
-  @nmcli@ radio wifi on
-  @nmcli@ device connect "${dev}"
+if [[ ${state} == "connected" ]]; then
+  @busctl@ --system call net.connman.iwd "${dev}" net.connman.iwd.Station Disconnect
+  exit 0
 fi
+
+@busctl@ --system set-property net.connman.iwd "${dev}" net.connman.iwd.Device Powered b true
+@busctl@ --system call net.connman.iwd "${dev}" net.connman.iwd.Station Scan 2>/dev/null || true
+for _ in 1 2 3 4 5; do
+  scanning=$(@busctl@ --system get-property net.connman.iwd "${dev}" net.connman.iwd.Station Scanning 2>/dev/null) || break
+  [[ ${scanning} != *true* ]] && break
+  sleep 1
+done
+
+ordered=$(@busctl@ --system -j call net.connman.iwd "${dev}" net.connman.iwd.Station GetOrderedNetworks 2>/dev/null) || exit 0
+objects=$(@busctl@ --system -j call net.connman.iwd / org.freedesktop.DBus.ObjectManager GetManagedObjects 2>/dev/null) || exit 0
+
+best=$(
+  # shellcheck disable=SC2016
+  @jq@ -n -r --argjson objects "${objects}" --argjson ordered "${ordered}" '
+    $objects.data[0] as $o
+    | $ordered.data[0][]
+    | .[0] as $path
+    | select($o[$path]["net.connman.iwd.Network"].KnownNetwork.data? != null)
+    | $path
+  ' 2>/dev/null | head -n1
+) || exit 0
+
+[[ -n ${best} ]] && @busctl@ --system call net.connman.iwd "${best}" net.connman.iwd.Network Connect

--- a/packages/waybar-network/wifi-toggle.bash
+++ b/packages/waybar-network/wifi-toggle.bash
@@ -9,7 +9,7 @@ set -euo pipefail
 # rather than relying on iwd's own autoconnect state machine.
 mapfile -t fields < <(@wifi-device@)
 dev="${fields[0]:-}"
-state="${fields[2]:-}"
+state="${fields[1]:-}"
 [[ -z ${dev} ]] && exit 0
 
 if [[ ${state} == "connected" ]]; then

--- a/tests/graphical.nix
+++ b/tests/graphical.nix
@@ -65,7 +65,11 @@ nixpkgs.testers.nixosTest {
         services.syncthing.enable = lib.mkForce false;
         environment.etc."thoughtfull-user-extra-groups".text =
           builtins.concatStringsSep "\n" config.thoughtfull.user.extraGroups;
-        environment.etc."networkmanager-wifi-backend".text = config.networking.networkmanager.wifi.backend;
+        environment.etc."networkmanager-unmanaged".text =
+          builtins.concatStringsSep "\n" config.networking.networkmanager.unmanaged;
+        environment.etc."wireless-enable".text = lib.boolToString config.networking.wireless.enable;
+        environment.etc."iwd-enable-network-configuration".text =
+          lib.boolToString config.networking.wireless.iwd.settings.General.EnableNetworkConfiguration;
       };
 
     disabled = {
@@ -85,9 +89,25 @@ nixpkgs.testers.nixosTest {
     with subtest("graphical enabled: user can control NetworkManager"):
         enabled.succeed("grep -Fx networkmanager /etc/thoughtfull-user-extra-groups")
 
-    with subtest("graphical enabled: iwmenu backend is configured"):
+    with subtest(
+        "graphical enabled: iwd manages Wi-Fi directly, NetworkManager only manages ethernet"
+    ):
+        # iwmenu (the Wi-Fi picker) talks to iwd's D-Bus API directly, so
+        # NetworkManager must not also be driving the same wifi device --
+        # the two fighting over the same iwd station is what broke wifi in
+        # the first place (see git history). NetworkManager keeps managing
+        # ethernet.
         enabled.succeed("systemctl cat iwd.service")
-        enabled.succeed("grep -Fx iwd /etc/networkmanager-wifi-backend")
+        enabled.succeed("grep -Fx type:wifi /etc/networkmanager-unmanaged")
+        # NetworkManager's module wants to enable this wpa_supplicant
+        # service itself whenever wifi.backend isn't "iwd" (deliberately
+        # not set here -- see graphical.nix for why), which would conflict
+        # with wireless.iwd.enable and break the build (`Only one wireless
+        # daemon is allowed at the time`).
+        enabled.succeed("grep -Fx false /etc/wireless-enable")
+        # iwd does its own IP configuration now that NetworkManager isn't
+        # managing the wifi device to run DHCP for it.
+        enabled.succeed("grep -Fx true /etc/iwd-enable-network-configuration")
 
     with subtest("graphical disabled: NetworkManager is not configured"):
         disabled.fail("systemctl cat NetworkManager.service")

--- a/tests/waybar.nix
+++ b/tests/waybar.nix
@@ -394,10 +394,12 @@ testPkgs.testers.nixosTest {
             "VPN should use the normal background when connected"
         )
 
-    with subtest("waybar-network-wifi reports a disabled state when NetworkManager is unavailable"):
-        # This test node doesn't enable networking.networkmanager, so nmcli
-        # has no daemon to talk to -- the widget should degrade gracefully
-        # rather than crash waybar's exec loop.
+    with subtest("waybar-network-wifi reports a disabled state when iwd is unavailable"):
+        # This test node doesn't enable networking.wireless.iwd, so there's
+        # no iwd daemon on the system bus for busctl to talk to -- the
+        # widget should degrade gracefully rather than crash waybar's exec
+        # loop. Wifi is queried via iwd directly (not nmcli/NetworkManager,
+        # which only manages ethernet -- see graphical.nix and tests/graphical.nix).
         out = machine.succeed("waybar-network-wifi").strip()
         print(f"waybar-network-wifi output: {out}")
         status = json.loads(out)


### PR DESCRIPTION
## Summary
- iwmenu talks to iwd's D-Bus API directly, but NetworkManager was also managing Wi-Fi via its iwd backend, so the two raced for control of the same station and repeatedly failed to connect
- NetworkManager now only manages ethernet (`unmanaged = ["type:wifi"]`); `wifi.backend` is deliberately left unset since setting it makes NetworkManager register as iwd's network-configuration D-Bus agent and reject iwd's own DHCP requests for this unmanaged device (`wireless.enable` is force-disabled directly instead to avoid the legacy wpa_supplicant conflict that setting was covering for)
- iwd now handles its own IP configuration and DNS via resolvconf (this system doesn't run systemd-resolved), and `/var/lib/iwd` is persisted under impermanence so saved networks survive a reboot
- `waybar-network-wifi`/`-toggle` are rewritten to query and drive iwd directly via busctl+jq instead of nmcli, preserving the 4-tier signal icon; `iwmenu` itself is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)