### PR TITLE
Allow unfree packages when building the test suite's nixpkgs

### DIFF
--- a/tests.nix
+++ b/tests.nix
@@ -9,7 +9,10 @@ in
 forEachSystem (
   system:
   let
-    nixpkgs = inputs.nixpkgs.legacyPackages.${system};
+    nixpkgs = import inputs.nixpkgs {
+      inherit system;
+      config.allowUnfree = true;
+    };
     callTest = path: import path { inherit self nixpkgs; };
   in
   {


### PR DESCRIPTION
## Summary
- `nix flake check` failed because `tests/default.nix` builds a NixOS test VM through `nixosModules/default.nix`, which unconditionally references the unfree `proton-pass-cli` package
- The test suite's shared `nixpkgs` binding in `tests.nix` still used nixpkgs' default (unfree-disallowed) config, so evaluating that module failed
- Fixed by instantiating the test suite's `nixpkgs` with `config.allowUnfree = true`, matching the pattern already used in `flake.nix`'s `packages` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)