### PR TITLE
Add a fuzzel menu for managing Ethernet connections from Waybar

### DIFF
--- a/nixosModules/sway/waybar/config.jsonc
+++ b/nixosModules/sway/waybar/config.jsonc
@@ -113,9 +113,9 @@
     "exec": "waybar-network-ethernet",
     "return-type": "json",
     "interval": 15,
-    "on-click": "waybar-network-ethernet-toggle",
+    "on-click": "waybar-network-ethernet-menu",
     "on-click-middle": "waybar-network-ethernet-toggle",
-    "on-click-right": "nm-connection-editor -t 802-3-ethernet -s"
+    "on-click-right": "waybar-network-ethernet-toggle"
   },
 
   "custom/network-vpn": {

--- a/packages/waybar-network.nix
+++ b/packages/waybar-network.nix
@@ -2,9 +2,11 @@
 let
   inherit (pkgs)
     bash
+    fuzzel
     gawk
     jq
     networkmanager
+    networkmanagerapplet
     symlinkJoin
     systemd
     ;
@@ -63,6 +65,16 @@ let
     };
     src = ./waybar-network/ethernet-toggle.bash;
   };
+  waybar-network-ethernet-menu = writeFileScriptBin {
+    name = "waybar-network-ethernet-menu";
+    replacements = {
+      bash = "${bash}/bin/bash";
+      fuzzel = "${fuzzel}/bin/fuzzel";
+      "nm-connection-editor" = "${networkmanagerapplet}/bin/nm-connection-editor";
+      nmcli = "${networkmanager}/bin/nmcli";
+    };
+    src = ./waybar-network/ethernet-menu.bash;
+  };
   waybar-network-vpn = writeFileScriptBin {
     name = "waybar-network-vpn";
     replacements = {
@@ -85,6 +97,7 @@ symlinkJoin {
   paths = [
     network-device
     waybar-network-ethernet
+    waybar-network-ethernet-menu
     waybar-network-ethernet-toggle
     waybar-network-vpn
     waybar-network-vpn-toggle

--- a/packages/waybar-network/ethernet-menu.bash
+++ b/packages/waybar-network/ethernet-menu.bash
@@ -38,9 +38,14 @@ while IFS=: read -r uuid type device name; do
   # backslash-escapes it, but it's still a literal ":" -- can't shift
   # UUID/TYPE/DEVICE out of place: `read` with a fixed variable count
   # folds any of its own remaining colons into the last variable intact.
-  # nmcli's terse output backslash-escapes literal colons within a field
-  # (e.g. a profile named "foo:bar"), same as wifi-status.bash's SSID.
+  # nmcli's terse output backslash-escapes literal colons (e.g. a profile
+  # named "foo:bar") and literal backslashes (e.g. "foo\bar" becomes
+  # "foo\\bar") so the colon-escape is unambiguous. Undo the backslash
+  # escape first via a placeholder so a doubled backslash doesn't get
+  # mistaken for an escaped colon partway through.
+  name="${name//\\\\/$'\x01'}"
   name="${name//\\:/:}"
+  name="${name//$'\x01'/\\}"
   menu_uuid+=("${uuid}")
   menu_device+=("${device}")
   menu_lines+=("${icon_connection} ${name}")
@@ -95,7 +100,13 @@ while true; do
       exit 0
       ;;
     "${delete_label}")
-      @nmcli@ connection delete uuid "${uuid}"
+      confirm_yes="Yes"
+      confirm_no="No"
+      confirm=$(
+        printf '%s\n' "${confirm_no}" "${confirm_yes}" |
+          @fuzzel@ --dmenu --minimal-lines --placeholder "Delete ${name}?"
+      )
+      [[ ${confirm} == "${confirm_yes}" ]] && @nmcli@ connection delete uuid "${uuid}"
       exit 0
       ;;
     "${back_label}")

--- a/packages/waybar-network/ethernet-menu.bash
+++ b/packages/waybar-network/ethernet-menu.bash
@@ -30,6 +30,7 @@ settings_label="${icon_settings} Settings"
 # used as an associative-array key.
 declare -a menu_uuid=()
 declare -a menu_device=()
+declare -a menu_name=()
 declare -a menu_lines=()
 while IFS=: read -r uuid type device name; do
   [[ ${type} == "802-3-ethernet" ]] || continue
@@ -48,6 +49,7 @@ while IFS=: read -r uuid type device name; do
   name="${name//$'\x01'/\\}"
   menu_uuid+=("${uuid}")
   menu_device+=("${device}")
+  menu_name+=("${name}")
   menu_lines+=("${icon_connection} ${name}")
 done < <(@nmcli@ -t -f UUID,TYPE,DEVICE,NAME connection show 2>/dev/null)
 
@@ -57,7 +59,11 @@ settings_index=${#menu_lines[@]}
 menu_lines+=("${settings_label}")
 
 while true; do
-  index=$(printf '%s\n' "${menu_lines[@]}" | @fuzzel@ --dmenu --minimal-lines --index)
+  # fuzzel exits non-zero (2 on Escape/right-click, 1 if dmenu mode never
+  # got a selection) whenever nothing was chosen, which `errexit` would
+  # otherwise treat as a script failure right at the assignment -- `|| true`
+  # neutralizes that so the explicit empty check below actually runs.
+  index=$(printf '%s\n' "${menu_lines[@]}" | @fuzzel@ --dmenu --minimal-lines --index) || true
   [[ -z ${index} ]] && exit 0
 
   if ((index == new_index)); then
@@ -70,7 +76,7 @@ while true; do
 
   uuid="${menu_uuid[index]}"
   device="${menu_device[index]}"
-  name="${menu_lines[index]#"${icon_connection} "}"
+  name="${menu_name[index]}"
 
   if [[ -n ${device} ]]; then
     connect_label="${icon_disconnect} Disconnect"
@@ -81,10 +87,12 @@ while true; do
   delete_label="${icon_delete} Delete"
   back_label="${icon_back} Back"
 
+  # See the `|| true` note above: a cancelled submenu must fall through to
+  # the `*)` case below instead of triggering `errexit`.
   sub_selection=$(
     printf '%s\n' "${connect_label}" "${edit_label}" "${delete_label}" "${back_label}" |
       @fuzzel@ --dmenu --minimal-lines --placeholder "Manage ${name}"
-  )
+  ) || true
 
   case "${sub_selection}" in
     "${connect_label}")
@@ -105,7 +113,7 @@ while true; do
       confirm=$(
         printf '%s\n' "${confirm_no}" "${confirm_yes}" |
           @fuzzel@ --dmenu --minimal-lines --placeholder "Delete ${name}?"
-      )
+      ) || true
       [[ ${confirm} == "${confirm_yes}" ]] && @nmcli@ connection delete uuid "${uuid}"
       exit 0
       ;;

--- a/packages/waybar-network/ethernet-menu.bash
+++ b/packages/waybar-network/ethernet-menu.bash
@@ -1,0 +1,108 @@
+#!@bash@
+set -euo pipefail
+
+# Fuzzel-driven menu for the Waybar custom/network-ethernet widget's primary
+# click. Lists every Ethernet connection profile (not just the currently
+# active one) so any saved profile can be connected, edited, or deleted.
+# Selecting a profile opens a submenu; "Back" returns here without exiting.
+
+icon_connection="󰈀"
+icon_connect="󰌷"
+icon_disconnect="󰌸"
+icon_edit=""
+icon_delete="󰗨"
+icon_back="󰁍"
+icon_new=""
+icon_settings="󰒓"
+
+new_label="${icon_new} New connection"
+settings_label="${icon_settings} Settings"
+
+# Queried once, up front: this script always exits immediately after any
+# action that could change connection state (connect/disconnect/delete),
+# so nothing can go stale underneath the "Back" path re-showing this same
+# list -- and skipping a second nmcli round-trip there avoids a visible
+# gap between the submenu closing and the top-level fuzzel reopening.
+#
+# Looked up by fuzzel's numeric --index rather than by matching the
+# displayed label text back to a map: two connection profiles are allowed
+# to share the same NAME, which would otherwise collide if the label were
+# used as an associative-array key.
+declare -a menu_uuid=()
+declare -a menu_device=()
+declare -a menu_lines=()
+while IFS=: read -r uuid type device name; do
+  [[ ${type} == "802-3-ethernet" ]] || continue
+  [[ -z ${name} ]] && continue
+  # NAME is queried last so a colon embedded in a profile name -- nmcli
+  # backslash-escapes it, but it's still a literal ":" -- can't shift
+  # UUID/TYPE/DEVICE out of place: `read` with a fixed variable count
+  # folds any of its own remaining colons into the last variable intact.
+  # nmcli's terse output backslash-escapes literal colons within a field
+  # (e.g. a profile named "foo:bar"), same as wifi-status.bash's SSID.
+  name="${name//\\:/:}"
+  menu_uuid+=("${uuid}")
+  menu_device+=("${device}")
+  menu_lines+=("${icon_connection} ${name}")
+done < <(@nmcli@ -t -f UUID,TYPE,DEVICE,NAME connection show 2>/dev/null)
+
+new_index=${#menu_lines[@]}
+menu_lines+=("${new_label}")
+settings_index=${#menu_lines[@]}
+menu_lines+=("${settings_label}")
+
+while true; do
+  index=$(printf '%s\n' "${menu_lines[@]}" | @fuzzel@ --dmenu --minimal-lines --index)
+  [[ -z ${index} ]] && exit 0
+
+  if ((index == new_index)); then
+    @nm-connection-editor@ -t 802-3-ethernet --create &
+    exit 0
+  elif ((index == settings_index)); then
+    @nm-connection-editor@ -t 802-3-ethernet -s &
+    exit 0
+  fi
+
+  uuid="${menu_uuid[index]}"
+  device="${menu_device[index]}"
+  name="${menu_lines[index]#"${icon_connection} "}"
+
+  if [[ -n ${device} ]]; then
+    connect_label="${icon_disconnect} Disconnect"
+  else
+    connect_label="${icon_connect} Connect"
+  fi
+  edit_label="${icon_edit} Edit"
+  delete_label="${icon_delete} Delete"
+  back_label="${icon_back} Back"
+
+  sub_selection=$(
+    printf '%s\n' "${connect_label}" "${edit_label}" "${delete_label}" "${back_label}" |
+      @fuzzel@ --dmenu --minimal-lines --placeholder "Manage ${name}"
+  )
+
+  case "${sub_selection}" in
+    "${connect_label}")
+      if [[ -n ${device} ]]; then
+        @nmcli@ connection down uuid "${uuid}"
+      else
+        @nmcli@ connection up uuid "${uuid}"
+      fi
+      exit 0
+      ;;
+    "${edit_label}")
+      @nm-connection-editor@ -e "${uuid}" &
+      exit 0
+      ;;
+    "${delete_label}")
+      @nmcli@ connection delete uuid "${uuid}"
+      exit 0
+      ;;
+    "${back_label}")
+      continue
+      ;;
+    *)
+      exit 0
+      ;;
+  esac
+done

--- a/packages/waybar-network/ethernet-status.bash
+++ b/packages/waybar-network/ethernet-status.bash
@@ -17,7 +17,7 @@ fi
 # such as "connected (externally)" for devices it didn't activate itself, so
 # match on the prefix rather than exact equality.
 if [[ ${state} == connected* ]]; then
-  printf '{"text": "󰈀", "tooltip": "Ethernet connected\\nClick to manage\\nMiddle/right-click to disconnect", "class": "connected"}\n'
+  printf '{"text": "󰈀", "tooltip": "Ethernet connected\\nClick to manage\\nRight-click to disconnect", "class": "connected"}\n'
 else
-  printf '{"text": "󰈀", "tooltip": "Ethernet disconnected\\nClick to manage\\nMiddle/right-click to reconnect", "class": "disconnected"}\n'
+  printf '{"text": "󰈀", "tooltip": "Ethernet disconnected\\nClick to manage\\nRight-click to reconnect", "class": "disconnected"}\n'
 fi

--- a/packages/waybar-network/ethernet-status.bash
+++ b/packages/waybar-network/ethernet-status.bash
@@ -17,7 +17,7 @@ fi
 # such as "connected (externally)" for devices it didn't activate itself, so
 # match on the prefix rather than exact equality.
 if [[ ${state} == connected* ]]; then
-  printf '{"text": "󰈀", "tooltip": "Ethernet connected\\nClick to disconnect", "class": "connected"}\n'
+  printf '{"text": "󰈀", "tooltip": "Ethernet connected\\nClick to manage\\nMiddle/right-click to disconnect", "class": "connected"}\n'
 else
-  printf '{"text": "󰈀", "tooltip": "Ethernet disconnected\\nClick to reconnect", "class": "disconnected"}\n'
+  printf '{"text": "󰈀", "tooltip": "Ethernet disconnected\\nClick to manage\\nMiddle/right-click to reconnect", "class": "disconnected"}\n'
 fi

--- a/tests/waybar.nix
+++ b/tests/waybar.nix
@@ -8,6 +8,69 @@ let
       lib = prev.lib.extend (_: _: { thoughtfull = self.lib.thoughtfull; });
     }
   );
+
+  # Fixture nmcli output for the ethernet-menu regression test below: one
+  # already-connected profile, plus profiles whose NAME exercises nmcli's
+  # terse-output escaping (an escaped colon, an escaped backslash, and both
+  # adjacent to each other) that ethernet-menu.bash must undo when it
+  # displays the name.
+  stubNmcli = testPkgs.writeShellScriptBin "nmcli" ''
+    set -euo pipefail
+    echo "nmcli $*" >>/tmp/nmcli-calls.log
+    if [[ "$1" == "-t" ]]; then
+      printf '%s\n' \
+        'uuid-plain:802-3-ethernet:eth0:Plain' \
+        'uuid-colon:802-3-ethernet::foo\:bar' \
+        'uuid-backslash:802-3-ethernet::back\\slash' \
+        'uuid-both:802-3-ethernet::a\\\:b'
+    fi
+  '';
+
+  # Stands in for the interactive fuzzel picker. Logs whatever menu it was
+  # shown (the thing under test -- this is how the ethernet-menu.bash
+  # regression test below observes the decoded profile names without a real
+  # Wayland session) and answers from a queue of 1-based line numbers in
+  # $FUZZEL_ANSWERS, one per invocation; "CANCEL" reproduces fuzzel's
+  # non-zero dmenu-cancel exit code instead of picking a line.
+  stubFuzzel = testPkgs.writeShellScriptBin "fuzzel" ''
+    set -euo pipefail
+    input=$(cat)
+    {
+      echo "== fuzzel $* =="
+      printf '%s\n' "$input"
+    } >>"$FUZZEL_LOG"
+
+    choice=$(head -n1 "$FUZZEL_ANSWERS")
+    sed -i '1d' "$FUZZEL_ANSWERS"
+
+    [[ ''${choice} == "CANCEL" ]] && exit 2
+
+    for arg in "$@"; do
+      if [[ ''${arg} == "--index" ]]; then
+        echo $((choice - 1))
+        exit 0
+      fi
+    done
+    printf '%s\n' "$input" | sed -n "''${choice}p"
+  '';
+
+  stubNmConnectionEditor = testPkgs.writeShellScriptBin "nm-connection-editor" ''
+    echo "nm-connection-editor $*" >>/tmp/nmcli-calls.log
+  '';
+
+  # The real ethernet-menu.bash rebuilt with nmcli/fuzzel replaced by the
+  # stubs above, so its parsing/escaping/index-lookup logic can be exercised
+  # end to end without real NetworkManager or a Wayland compositor.
+  testEthernetMenu = testPkgs.thoughtfull.writeFileScriptBin {
+    name = "waybar-network-ethernet-menu-test";
+    replacements = {
+      bash = "${testPkgs.bash}/bin/bash";
+      fuzzel = "${stubFuzzel}/bin/fuzzel";
+      "nm-connection-editor" = "${stubNmConnectionEditor}/bin/nm-connection-editor";
+      nmcli = "${stubNmcli}/bin/nmcli";
+    };
+    src = ../packages/waybar-network/ethernet-menu.bash;
+  };
 in
 testPkgs.testers.nixosTest {
   name = "waybar";
@@ -56,6 +119,7 @@ testPkgs.testers.nixosTest {
         environment.systemPackages = [
           pkgs.netcat
           pkgs.thoughtfull.waybar-displays
+          testEthernetMenu
         ];
 
         # Create a test user for user services
@@ -420,6 +484,75 @@ testPkgs.testers.nixosTest {
         status = json.loads(out)
         assert status["class"] == "disabled", f"expected a disabled state, got: {out}"
         assert status["text"] == "󰈀", f"expected icon-only Ethernet text, got: {out}"
+
+    with subtest(
+        "waybar-network-ethernet-menu decodes escaped profile names and manages connections"
+    ):
+        # Exercises the real script (waybar-network-ethernet-menu-test, built
+        # from the same source as waybar-network-ethernet-menu but with
+        # nmcli/fuzzel replaced by stubs -- see stubNmcli/stubFuzzel above)
+        # against fixture nmcli output, without a real NetworkManager or
+        # Wayland compositor.
+        fuzzel_log = "/tmp/fuzzel-menu.log"
+        answers = "/tmp/fuzzel-answers"
+
+        def run_menu(*choices):
+            machine.succeed(f"rm -f {fuzzel_log} /tmp/nmcli-calls.log")
+            machine.succeed(
+                "printf '%s\\n' " + " ".join(choices) + f" >{answers}"
+            )
+            machine.succeed(
+                f"FUZZEL_LOG={fuzzel_log} FUZZEL_ANSWERS={answers} "
+                "waybar-network-ethernet-menu-test"
+            )
+
+        # Cancelling the very first prompt is enough to inspect the
+        # top-level list: it must show profile names with nmcli's
+        # colon/backslash escaping already undone, not the raw escaped form.
+        run_menu("CANCEL")
+        top_level = machine.succeed(f"cat {fuzzel_log}")
+        assert "foo:bar" in top_level, f"expected decoded colon name, got: {top_level}"
+        assert "back\\slash" in top_level, (
+            f"expected decoded backslash name, got: {top_level}"
+        )
+        assert "a\\:b" in top_level, f"expected decoded mixed-escape name, got: {top_level}"
+        assert "foo\\:bar" not in top_level, (
+            f"colon escape should have been undone, got: {top_level}"
+        )
+        assert "back\\\\slash" not in top_level, (
+            f"backslash escape should have been undone, got: {top_level}"
+        )
+
+        # Selecting the already-connected "Plain" profile (list line 1) then
+        # "Disconnect" (submenu line 1, since it has a device) must resolve
+        # back to the right uuid via the --index lookup, not just the label.
+        run_menu("1", "1")
+        calls = machine.succeed("cat /tmp/nmcli-calls.log")
+        assert "connection down uuid uuid-plain" in calls, f"expected disconnect call, got: {calls}"
+
+        # Selecting a disconnected profile and choosing Connect uses the same
+        # index-derived uuid path as Disconnect, but runs the opposite nmcli
+        # action when the fixture has no active device.
+        run_menu("2", "1")
+        calls = machine.succeed("cat /tmp/nmcli-calls.log")
+        assert "connection up uuid uuid-colon" in calls, f"expected connect call, got: {calls}"
+
+        # Back returns to the already-snapshotted top-level menu, where the
+        # Settings item can still be selected.
+        run_menu("2", "4", "6")
+        calls = machine.succeed("cat /tmp/nmcli-calls.log")
+        assert "nm-connection-editor -t 802-3-ethernet -s" in calls, (
+            f"expected settings call after Back, got: {calls}"
+        )
+
+        # Selecting the colon-escaped profile (list line 2), then Delete
+        # (submenu line 3) and confirming Yes (confirm line 2) must delete
+        # the uuid belonging to that profile, not a neighboring one --
+        # exercising both the delete confirmation flow and that the index
+        # lookup still lines up correctly for a profile with an escaped name.
+        run_menu("2", "3", "2")
+        calls = machine.succeed("cat /tmp/nmcli-calls.log")
+        assert "connection delete uuid uuid-colon" in calls, f"expected delete call, got: {calls}"
 
     with subtest("waybar-network-vpn is disabled when vpn.service is absent"):
         out = noVpn.succeed("waybar-network-vpn").strip()

--- a/tests/waybar.nix
+++ b/tests/waybar.nix
@@ -340,13 +340,13 @@ testPkgs.testers.nixosTest {
         )
         machine.succeed('grep -q \'"exec": "waybar-network-ethernet"\' /etc/xdg/waybar/config.jsonc')
         machine.succeed(
-            'grep -q \'"on-click": "waybar-network-ethernet-toggle"\' /etc/xdg/waybar/config.jsonc'
+            'grep -q \'"on-click": "waybar-network-ethernet-menu"\' /etc/xdg/waybar/config.jsonc'
         )
         machine.succeed(
             'grep -q \'"on-click-middle": "waybar-network-ethernet-toggle"\' /etc/xdg/waybar/config.jsonc'
         )
         machine.succeed(
-            'grep -q \'"on-click-right": "nm-connection-editor -t 802-3-ethernet -s"\' /etc/xdg/waybar/config.jsonc'
+            'grep -q \'"on-click-right": "waybar-network-ethernet-toggle"\' /etc/xdg/waybar/config.jsonc'
         )
         machine.succeed('grep -q \'"exec": "waybar-network-vpn"\' /etc/xdg/waybar/config.jsonc')
         machine.succeed(


### PR DESCRIPTION
## Summary
- Left-click on the Waybar Ethernet widget now opens a nested fuzzel menu listing NetworkManager Ethernet connection profiles, with Connect/Disconnect, Edit (`nm-connection-editor -e <uuid>`), and Delete per profile, plus Back to return to the list.
- Top level also offers New connection (`nm-connection-editor -t 802-3-ethernet --create`) and Settings (`nm-connection-editor -t 802-3-ethernet -s`).
- Right-click now toggles the connection (same as middle-click), since Settings is reachable from the new menu.
- Connection list is fetched once per invocation (not re-queried on "Back") and profiles are looked up by fuzzel's `--index` rather than by matching the displayed label text, so connections with colons in their name or duplicate names are both handled correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)