### PR TITLE
Distinguish disabled Wi-Fi radio from a plain disconnect

### DIFF
--- a/nixosModules/mako/config
+++ b/nixosModules/mako/config
@@ -35,6 +35,13 @@ border-size=0
 on-notify=none
 border-size=0
 
+# iwmenu (waybar-network-wifi-menu) fires a desktop notification for every
+# network action (connect, disconnect, adapter power, etc.) with no CLI
+# flag to disable them, so suppress them outright here instead.
+[app-name=iwmenu]
+invisible=1
+on-notify=none
+
 [urgency=high]
 background-color=#c01c28
 border-color=#c01c28

--- a/nixosModules/sway/waybar/config.jsonc
+++ b/nixosModules/sway/waybar/config.jsonc
@@ -103,7 +103,8 @@
     "exec": "waybar-network-wifi",
     "return-type": "json",
     "interval": 15,
-    "on-click": "iwmenu --launcher fuzzel",
+    "signal": 5,
+    "on-click": "waybar-network-wifi-menu",
     "on-click-middle": "waybar-network-wifi-toggle",
     "on-click-right": "waybar-network-wifi-toggle"
   },

--- a/nixosModules/sway/waybar/style.css
+++ b/nixosModules/sway/waybar/style.css
@@ -61,7 +61,6 @@ window#waybar {
   padding: 0 12pt 0 6pt;
 }
 
-#custom-network-wifi.disconnected,
 #custom-network-ethernet.disconnected,
 #custom-network-vpn.disconnected,
 #custom-network-wifi.disabled,

--- a/packages/waybar-network.nix
+++ b/packages/waybar-network.nix
@@ -5,6 +5,7 @@ let
     gawk
     jq
     networkmanager
+    procps
     symlinkJoin
     systemd
     ;
@@ -42,9 +43,20 @@ let
       bash = "${bash}/bin/bash";
       busctl = "${systemd}/bin/busctl";
       jq = "${jq}/bin/jq";
+      pkill = "${procps}/bin/pkill";
       wifi-device = "${wifi-device}/bin/waybar-network-wifi-device";
     };
     src = ./waybar-network/wifi-toggle.bash;
+  };
+  waybar-network-wifi-menu = writeFileScriptBin {
+    name = "waybar-network-wifi-menu";
+    replacements = {
+      bash = "${bash}/bin/bash";
+      busctl = "${systemd}/bin/busctl";
+      pkill = "${procps}/bin/pkill";
+      wifi-device = "${wifi-device}/bin/waybar-network-wifi-device";
+    };
+    src = ./waybar-network/wifi-menu.bash;
   };
   waybar-network-ethernet = writeFileScriptBin {
     name = "waybar-network-ethernet";
@@ -89,6 +101,7 @@ symlinkJoin {
     waybar-network-vpn
     waybar-network-vpn-toggle
     waybar-network-wifi
+    waybar-network-wifi-menu
     waybar-network-wifi-toggle
     wifi-device
   ];

--- a/packages/waybar-network/wifi-device.bash
+++ b/packages/waybar-network/wifi-device.bash
@@ -2,15 +2,27 @@
 set -euo pipefail
 
 # Prints the iwd station device's object path, station state, connected
-# SSID, and (while connected) RSSI in dBm -- one per line -- or nothing if
-# no wifi device exists (or iwd is unreachable). Wifi is owned directly by
-# iwd rather than NetworkManager (see graphical.nix), so this queries
-# iwd's D-Bus objects instead of nmcli, which network-device.bash uses for
-# the NetworkManager-managed ethernet device. Shared by wifi-status.bash
-# and wifi-toggle.bash so this discovery logic only lives in one place --
-# same reasoning as network-device.bash.
+# SSID, (while connected) RSSI in dBm, and whether the radio is powered --
+# one per line -- or nothing if no wifi device exists (or iwd is
+# unreachable). Wifi is owned directly by iwd rather than NetworkManager
+# (see graphical.nix), so this queries iwd's D-Bus objects instead of
+# nmcli, which network-device.bash uses for the NetworkManager-managed
+# ethernet device. Shared by wifi-status.bash and wifi-toggle.bash so this
+# discovery logic only lives in one place -- same reasoning as
+# network-device.bash.
+#
+# The Device interface (and its Mode/Powered properties) persists even
+# when the radio is powered off, but iwd drops the Station interface
+# entirely in that case -- so State/ConnectedNetwork naturally fall back
+# to "disconnected"/"" below, and Powered is the only reliable signal for
+# distinguishing "off" from "on but disconnected".
 objects=$(@busctl@ --system -j call net.connman.iwd / org.freedesktop.DBus.ObjectManager GetManagedObjects 2>/dev/null) || exit 0
 
+# Fields are joined with the unit separator (\x1f), not a tab: bash's read
+# treats tab as "IFS whitespace" and collapses consecutive delimiters, so
+# an empty field (ssid, whenever disconnected) would silently swallow a
+# tab and shift every field after it left -- \x1f isn't whitespace, so
+# empty fields are preserved correctly.
 # shellcheck disable=SC2016
 parsed=$(@jq@ -r '
   .data[0] as $objs
@@ -19,12 +31,13 @@ parsed=$(@jq@ -r '
   | [
       $d.key,
       ($d.value["net.connman.iwd.Station"].State.data // "disconnected"),
-      (if $net != "" then $objs[$net]["net.connman.iwd.Network"].Name.data else "" end)
-    ] | @tsv
+      (if $net != "" then $objs[$net]["net.connman.iwd.Network"].Name.data else "" end),
+      (if $d.value["net.connman.iwd.Device"].Powered.data == true then "true" else "false" end)
+    ] | join("")
 ' <<<"${objects}" 2>/dev/null) || exit 0
 [[ -z ${parsed} ]] && exit 0
 
-IFS=$'\t' read -r dev state ssid <<<"${parsed}"
+IFS=$'\x1f' read -r dev state ssid powered <<<"${parsed}"
 
 rssi=""
 if [[ ${state} == "connected" ]]; then
@@ -34,4 +47,4 @@ if [[ ${state} == "connected" ]]; then
   ) || rssi=""
 fi
 
-printf '%s\n' "${dev}" "${state}" "${ssid}" "${rssi}"
+printf '%s\n' "${dev}" "${state}" "${ssid}" "${rssi}" "${powered}"

--- a/packages/waybar-network/wifi-device.bash
+++ b/packages/waybar-network/wifi-device.bash
@@ -26,14 +26,16 @@ objects=$(@busctl@ --system -j call net.connman.iwd / org.freedesktop.DBus.Objec
 # shellcheck disable=SC2016
 parsed=$(@jq@ -r '
   .data[0] as $objs
-  | ($objs | to_entries[] | select(.value["net.connman.iwd.Device"].Mode.data? == "station")) as $d
+  # This widget only has room for one Wi-Fi icon, so if a machine has more
+  # than one station-mode device, only the first one found is reported.
+  | first($objs | to_entries[] | select(.value["net.connman.iwd.Device"].Mode.data? == "station")) as $d
   | ($d.value["net.connman.iwd.Station"].ConnectedNetwork.data // "") as $net
   | [
       $d.key,
       ($d.value["net.connman.iwd.Station"].State.data // "disconnected"),
       (if $net != "" then $objs[$net]["net.connman.iwd.Network"].Name.data else "" end),
       (if $d.value["net.connman.iwd.Device"].Powered.data == true then "true" else "false" end)
-    ] | join("")
+    ] | join("\u001f")
 ' <<<"${objects}" 2>/dev/null) || exit 0
 [[ -z ${parsed} ]] && exit 0
 

--- a/packages/waybar-network/wifi-menu.bash
+++ b/packages/waybar-network/wifi-menu.bash
@@ -1,0 +1,38 @@
+#!@bash@
+set -euo pipefail
+
+# Powers on the Wi-Fi radio (if it's off) before launching iwmenu, so its
+# network-selection menu shows up directly instead of iwmenu's own "Power
+# on device" prompt. That prompt doesn't actually gate anything useful:
+# iwmenu only picks up iwd's Station D-Bus interface (and so only shows a
+# network list) if the radio was already powered when iwmenu started --
+# see iwd-device.bash for why Station only exists while powered. Selecting
+# "Power on device" works by reinitializing everything from scratch, but
+# escaping just quits with the radio silently left on and no menu shown.
+# Powering on ourselves first sidesteps that prompt entirely.
+#
+# custom/network-wifi polls on a 15s interval and iwmenu's own menu
+# actions (connect, disconnect, forget) don't know to poke it, so nudge it
+# (signal 5) both right after we power on and once iwmenu exits -- whatever
+# changed inside its menu shows up immediately instead of waiting out the
+# interval.
+mapfile -t fields < <(@wifi-device@)
+dev="${fields[0]:-}"
+powered="${fields[4]:-}"
+
+if [[ -n ${dev} && ${powered} != "true" ]]; then
+  @busctl@ --system set-property net.connman.iwd "${dev}" net.connman.iwd.Device Powered b true
+  @pkill@ -RTMIN+5 -x waybar || true
+  # Real hardware can take a few seconds to bring the interface up (driver
+  # firmware load, etc.) before iwd registers the Station interface --
+  # launching iwmenu before that happens makes it silently quit with no
+  # menu shown at all (see comment above), so wait longer than it should
+  # ever actually take rather than risk cutting this off early.
+  for _ in $(seq 1 20); do
+    @busctl@ --system get-property net.connman.iwd "${dev}" net.connman.iwd.Station Scanning &>/dev/null && break
+    sleep 0.25
+  done
+fi
+
+iwmenu --launcher fuzzel || true
+@pkill@ -RTMIN+5 -x waybar || true

--- a/packages/waybar-network/wifi-menu.bash
+++ b/packages/waybar-network/wifi-menu.bash
@@ -6,7 +6,7 @@ set -euo pipefail
 # on device" prompt. That prompt doesn't actually gate anything useful:
 # iwmenu only picks up iwd's Station D-Bus interface (and so only shows a
 # network list) if the radio was already powered when iwmenu started --
-# see iwd-device.bash for why Station only exists while powered. Selecting
+# see wifi-device.bash for why Station only exists while powered. Selecting
 # "Power on device" works by reinitializing everything from scratch, but
 # escaping just quits with the radio silently left on and no menu shown.
 # Powering on ourselves first sidesteps that prompt entirely.
@@ -21,17 +21,28 @@ dev="${fields[0]:-}"
 powered="${fields[4]:-}"
 
 if [[ -n ${dev} && ${powered} != "true" ]]; then
-  @busctl@ --system set-property net.connman.iwd "${dev}" net.connman.iwd.Device Powered b true
+  # A failed power-on shouldn't abort the script under set -e and leave
+  # iwmenu never even attempted -- fall through and let iwmenu try anyway,
+  # same as if we hadn't powered on at all.
+  @busctl@ --system set-property net.connman.iwd "${dev}" net.connman.iwd.Device Powered b true || true
   @pkill@ -RTMIN+5 -x waybar || true
   # Real hardware can take a few seconds to bring the interface up (driver
   # firmware load, etc.) before iwd registers the Station interface --
   # launching iwmenu before that happens makes it silently quit with no
   # menu shown at all (see comment above), so wait longer than it should
-  # ever actually take rather than risk cutting this off early.
+  # ever actually take rather than risk cutting this off early. If it still
+  # never comes up, say so on stderr rather than launching iwmenu into the
+  # same silent failure this script exists to avoid.
+  station_ready=false
   for _ in $(seq 1 20); do
-    @busctl@ --system get-property net.connman.iwd "${dev}" net.connman.iwd.Station Scanning &>/dev/null && break
+    if @busctl@ --system get-property net.connman.iwd "${dev}" net.connman.iwd.Station Scanning &>/dev/null; then
+      station_ready=true
+      break
+    fi
     sleep 0.25
   done
+  [[ ${station_ready} == false ]] &&
+    echo "wifi-menu: iwd's Station interface never came up after powering on; launching iwmenu anyway" >&2
 fi
 
 iwmenu --launcher fuzzel || true

--- a/packages/waybar-network/wifi-status.bash
+++ b/packages/waybar-network/wifi-status.bash
@@ -9,9 +9,15 @@ dev="${fields[0]:-}"
 state="${fields[1]:-}"
 ssid="${fields[2]:-}"
 rssi="${fields[3]:-}"
+powered="${fields[4]:-}"
 
 if [[ -z ${dev} ]]; then
-  printf '{"text": "󰤯", "tooltip": "No Wi-Fi device", "class": "disabled"}\n'
+  printf '{"text": "󰤭", "tooltip": "No Wi-Fi device", "class": "disabled"}\n'
+  exit 0
+fi
+
+if [[ ${powered} != "true" ]]; then
+  printf '{"text": "󰤭", "tooltip": "Wi-Fi disabled\\nClick to browse networks\\nRight-click to enable", "class": "disabled"}\n'
   exit 0
 fi
 
@@ -30,7 +36,7 @@ if [[ ${state} == "connected" ]]; then
   fi
   # shellcheck disable=SC2016
   @jq@ -cn --arg icon "${icon}" --arg ssid "${ssid}" --arg rssi "${rssi}" \
-    '{text: $icon, tooltip: ("Wi-Fi: " + $ssid + " (" + $rssi + " dBm)\nClick to browse networks\nRight-click to disconnect"), class: "connected"}'
+    '{text: $icon, tooltip: ("Wi-Fi: " + $ssid + " (" + $rssi + " dBm)\nClick to browse networks\nRight-click to disable"), class: "connected"}'
 else
-  printf '{"text": "󰤯", "tooltip": "Wi-Fi disconnected\\nClick to browse networks\\nRight-click to reconnect", "class": "disconnected"}\n'
+  printf '{"text": "󰤯", "tooltip": "Wi-Fi disconnected\\nClick to browse networks\\nRight-click to disable", "class": "disconnected"}\n'
 fi

--- a/packages/waybar-network/wifi-toggle.bash
+++ b/packages/waybar-network/wifi-toggle.bash
@@ -26,13 +26,16 @@ dev="${fields[0]:-}"
 powered="${fields[4]:-}"
 [[ -z ${dev} ]] && exit 0
 
+# A failed set-property shouldn't abort the script under set -e before the
+# refresh below runs -- if it really failed, the icon just reflects that
+# nothing changed, which is accurate.
 if [[ ${powered} == "true" ]]; then
-  @busctl@ --system set-property net.connman.iwd "${dev}" net.connman.iwd.Device Powered b false
+  @busctl@ --system set-property net.connman.iwd "${dev}" net.connman.iwd.Device Powered b false || true
   @pkill@ -RTMIN+5 -x waybar || true
   exit 0
 fi
 
-@busctl@ --system set-property net.connman.iwd "${dev}" net.connman.iwd.Device Powered b true
+@busctl@ --system set-property net.connman.iwd "${dev}" net.connman.iwd.Device Powered b true || true
 @pkill@ -RTMIN+5 -x waybar || true
 for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
   @busctl@ --system get-property net.connman.iwd "${dev}" net.connman.iwd.Station Scanning &>/dev/null && break
@@ -45,19 +48,20 @@ for _ in 1 2 3 4 5; do
   sleep 1
 done
 
+# GetOrderedNetworks returns every visible network (known or not), sorted
+# best-signal-first. KnownNetwork is only present on a Network object at
+# all if it's actually a known one, so a per-candidate property read (not
+# a full ObjectManager tree dump) is enough to find the first one we can
+# connect to.
 ordered=$(@busctl@ --system -j call net.connman.iwd "${dev}" net.connman.iwd.Station GetOrderedNetworks 2>/dev/null) || exit 0
-objects=$(@busctl@ --system -j call net.connman.iwd / org.freedesktop.DBus.ObjectManager GetManagedObjects 2>/dev/null) || exit 0
 
-best=$(
-  # shellcheck disable=SC2016
-  @jq@ -n -r --argjson objects "${objects}" --argjson ordered "${ordered}" '
-    $objects.data[0] as $o
-    | $ordered.data[0][]
-    | .[0] as $path
-    | select($o[$path]["net.connman.iwd.Network"].KnownNetwork.data? != null)
-    | $path
-  ' 2>/dev/null | head -n1
-) || exit 0
+best=""
+while IFS= read -r path; do
+  if @busctl@ --system get-property net.connman.iwd "${path}" net.connman.iwd.Network KnownNetwork &>/dev/null; then
+    best="${path}"
+    break
+  fi
+done < <(@jq@ -r '.data[0][][0] // empty' <<<"${ordered}" 2>/dev/null)
 
 if [[ -n ${best} ]]; then
   @busctl@ --system call net.connman.iwd "${best}" net.connman.iwd.Network Connect

--- a/packages/waybar-network/wifi-toggle.bash
+++ b/packages/waybar-network/wifi-toggle.bash
@@ -1,23 +1,39 @@
 #!@bash@
 set -euo pipefail
 
-# Toggles the Wi-Fi device found by wifi-device: disconnects it if
-# connected, otherwise connects to the best-signal known network in range --
-# the iwd equivalent of nmcli's best-available-connection reconnect. iwd
-# doesn't autoconnect just because the radio is powered on (an explicit
-# Disconnect suppresses it), so this has to pick and connect explicitly
-# rather than relying on iwd's own autoconnect state machine.
+# Toggles the Wi-Fi device found by wifi-device: powers the radio off if
+# it's currently on, otherwise powers it on and connects to the
+# best-signal known network in range -- the iwd equivalent of nmcli's
+# best-available-connection reconnect. iwd doesn't autoconnect just
+# because the radio is powered on: any explicit Disconnect (from here,
+# from wifi-menu.bash's iwmenu, wherever) permanently flips iwd's own
+# per-station autoconnect flag off -- see station_dbus_disconnect() in
+# iwd's src/station.c ("Disconnect was triggered by the user, don't
+# autoconnect"). Nothing resets that flag except an explicit Connect()
+# (which is what we do below) or the Station object being destroyed and
+# recreated, which only happens by powering the radio fully off and back
+# on -- station_create() defaults autoconnect back to true. So this has
+# to pick and connect explicitly rather than relying on iwd's own
+# autoconnect state machine, and disconnecting once means the *only* way
+# back to autoconnecting is either an explicit reconnect (left-click ->
+# iwmenu) or a full disable/enable cycle through this script.
+#
+# custom/network-wifi polls on a 15s interval, so without an explicit
+# nudge here the icon would show stale state for up to that long after
+# every action. Refresh it (signal 5) after each state change.
 mapfile -t fields < <(@wifi-device@)
 dev="${fields[0]:-}"
-state="${fields[1]:-}"
+powered="${fields[4]:-}"
 [[ -z ${dev} ]] && exit 0
 
-if [[ ${state} == "connected" ]]; then
-  @busctl@ --system call net.connman.iwd "${dev}" net.connman.iwd.Station Disconnect
+if [[ ${powered} == "true" ]]; then
+  @busctl@ --system set-property net.connman.iwd "${dev}" net.connman.iwd.Device Powered b false
+  @pkill@ -RTMIN+5 -x waybar || true
   exit 0
 fi
 
 @busctl@ --system set-property net.connman.iwd "${dev}" net.connman.iwd.Device Powered b true
+@pkill@ -RTMIN+5 -x waybar || true
 @busctl@ --system call net.connman.iwd "${dev}" net.connman.iwd.Station Scan 2>/dev/null || true
 for _ in 1 2 3 4 5; do
   scanning=$(@busctl@ --system get-property net.connman.iwd "${dev}" net.connman.iwd.Station Scanning 2>/dev/null) || break
@@ -39,4 +55,7 @@ best=$(
   ' 2>/dev/null | head -n1
 ) || exit 0
 
-[[ -n ${best} ]] && @busctl@ --system call net.connman.iwd "${best}" net.connman.iwd.Network Connect
+if [[ -n ${best} ]]; then
+  @busctl@ --system call net.connman.iwd "${best}" net.connman.iwd.Network Connect
+  @pkill@ -RTMIN+5 -x waybar || true
+fi

--- a/packages/waybar-network/wifi-toggle.bash
+++ b/packages/waybar-network/wifi-toggle.bash
@@ -34,6 +34,10 @@ fi
 
 @busctl@ --system set-property net.connman.iwd "${dev}" net.connman.iwd.Device Powered b true
 @pkill@ -RTMIN+5 -x waybar || true
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+  @busctl@ --system get-property net.connman.iwd "${dev}" net.connman.iwd.Station Scanning &>/dev/null && break
+  sleep 0.25
+done
 @busctl@ --system call net.connman.iwd "${dev}" net.connman.iwd.Station Scan 2>/dev/null || true
 for _ in 1 2 3 4 5; do
   scanning=$(@busctl@ --system get-property net.connman.iwd "${dev}" net.connman.iwd.Station Scanning 2>/dev/null) || break

--- a/tests/waybar.nix
+++ b/tests/waybar.nix
@@ -329,8 +329,12 @@ testPkgs.testers.nixosTest {
             )
 
         machine.succeed('grep -q \'"exec": "waybar-network-wifi"\' /etc/xdg/waybar/config.jsonc')
+        # wifi-toggle.bash and wifi-menu.bash both poke this signal after
+        # changing state, so the icon updates immediately instead of
+        # waiting out the 15s poll interval.
+        machine.succeed('grep -q \'"signal": 5\' /etc/xdg/waybar/config.jsonc')
         machine.succeed(
-            'grep -q \'"on-click": "iwmenu --launcher fuzzel"\' /etc/xdg/waybar/config.jsonc'
+            'grep -q \'"on-click": "waybar-network-wifi-menu"\' /etc/xdg/waybar/config.jsonc'
         )
         machine.succeed(
             'grep -q \'"on-click-middle": "waybar-network-wifi-toggle"\' /etc/xdg/waybar/config.jsonc'
@@ -404,12 +408,12 @@ testPkgs.testers.nixosTest {
         print(f"waybar-network-wifi output: {out}")
         status = json.loads(out)
         assert status["class"] == "disabled", f"expected a disabled state, got: {out}"
-        assert status["text"] == "󰤯", f"expected icon-only Wi-Fi text, got: {out}"
+        assert status["text"] == "󰤭", f"expected the slashed Wi-Fi icon, got: {out}"
 
         waybar_network_dir = machine.succeed(
             "dirname $(readlink -f $(command -v waybar-network-wifi))"
         ).strip()
-        for icon in ["󰤟", "󰤢", "󰤥", "󰤨"]:
+        for icon in ["󰤟", "󰤢", "󰤥", "󰤨", "󰤯", "󰤭"]:
             machine.succeed(f"grep -R -q '{icon}' {waybar_network_dir}")
 
     with subtest(


### PR DESCRIPTION
## Summary
- The waybar Wi-Fi widget now shows a distinct slashed/grayed icon when the radio is powered off, separate from the plain ungrayed icon used when it's merely disconnected from a network.
- Right/middle-click toggles the radio's power instead of just disconnecting; left-click powers the radio on first (if needed) before launching `iwmenu` so its menu appears directly instead of iwmenu's own non-functional "power on device" prompt.
- Fixed a real bug uncovered along the way: `wifi-device.bash` split fields on a tab, which bash's `read` collapses between consecutive delimiters, silently corrupting the parsed state whenever the SSID field was empty (i.e. always, while disconnected) -- switched to the unit separator (`\x1f`) instead.
- Fixed another bug where `pkill`'s default substring matching against process names caused our own scripts (named `waybar-network-wifi-*`) to kill themselves mid-run when signaling waybar to refresh, since their own names contain "waybar" -- added `-x` for exact matching.
- Suppresses iwmenu's own desktop notifications via a mako rule, since it fires them unconditionally with no way to disable them itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)