### PR TITLE
Replace pasystray with mic/speaker Waybar widgets

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,7 @@
             theme-toggle
             uns
             usb-menu
+            waybar-audio
             waybar-displays
             waybar-network
             waybar-weather

--- a/nixosModules/sway.nix
+++ b/nixosModules/sway.nix
@@ -93,7 +93,7 @@ in
     # gtk-defaults sets the GTK icon/cursor/font theme via gsettings. Ordering
     # the whole session target after it (rather than having every consumer
     # order after gtk-defaults.service individually) means anything
-    # WantedBy=sway-session.target -- waybar, pasystray, blueman-applet, etc.
+    # WantedBy=sway-session.target -- waybar, blueman-applet, etc.
     # -- is guaranteed to start only once the theme is actually applied.
     after = [ "gtk-defaults.service" ];
   };

--- a/nixosModules/sway/waybar.nix
+++ b/nixosModules/sway/waybar.nix
@@ -16,12 +16,13 @@ let
     iwmenu
     networkmanager
     networkmanagerapplet
-    pasystray
+    pulseaudio
     waybar
     wdisplays
     ;
   inherit (pkgs.thoughtfull)
     theme-toggle
+    waybar-audio
     waybar-displays
     waybar-network
     waybar-yubikey
@@ -40,9 +41,9 @@ in
       iwmenu
       networkmanager
       networkmanagerapplet
-      pasystray
       power-menu
       waybar
+      waybar-audio
       waybar-network
       waybar-yubikey
     ];
@@ -75,17 +76,6 @@ in
       };
     };
     user.services = mkIf cfg.enable {
-      pasystray = {
-        after = [ "sway-session.target" ];
-        bindsTo = [ "sway-session.target" ];
-        enable = mkDefault sway.enable;
-        wantedBy = [ "sway-session.target" ];
-        serviceConfig = {
-          ExecStart = "${pasystray}/bin/pasystray -N none";
-          Restart = "on-failure";
-          RestartSec = 1;
-        };
-      };
       waybar = {
         # sway-session.target itself is ordered after gtk-defaults.service
         # (nixosModules/sway.nix), so waiting on the target alone already
@@ -100,7 +90,9 @@ in
           networkmanager
           networkmanagerapplet
           power-menu
+          pulseaudio
           theme-toggle
+          waybar-audio
           waybar-displays
           waybar-network
           waybar-yubikey

--- a/nixosModules/sway/waybar/config.jsonc
+++ b/nixosModules/sway/waybar/config.jsonc
@@ -6,7 +6,7 @@
 
   "modules-left": ["sway/workspaces", "sway/scratchpad" ],
   "modules-center": [],
-  "modules-right": ["sway/mode", "custom/yubikey", "custom/weather", "clock", "clock#utc", "battery", "custom/network-wifi", "custom/network-ethernet", "custom/network-vpn", "tray", "custom/displays", "custom/theme", "custom/lock", "custom/power"],
+  "modules-right": ["sway/mode", "custom/yubikey", "custom/weather", "clock", "clock#utc", "battery", "custom/network-wifi", "custom/network-ethernet", "custom/network-vpn", "custom/audio-mic", "custom/audio-speaker", "tray", "custom/displays", "custom/theme", "custom/lock", "custom/power"],
 
   "sway/workspaces": {
     "disable-scroll": false,
@@ -127,6 +127,28 @@
     "on-click": "waybar-network-vpn-toggle",
     "on-click-middle": "waybar-network-vpn-toggle",
     "on-click-right": "waybar-network-vpn-toggle"
+  },
+
+  "custom/audio-mic": {
+    "format": "<span font=\"20px\">{}</span>",
+    "exec": "waybar-audio-mic",
+    "return-type": "json",
+    "interval": 15,
+    "signal": 7,
+    "on-click": "waybar-audio-mic-menu",
+    "on-click-middle": "waybar-audio-mic-toggle",
+    "on-click-right": "waybar-audio-mic-toggle"
+  },
+
+  "custom/audio-speaker": {
+    "format": "<span font=\"20px\">{}</span>",
+    "exec": "waybar-audio-speaker",
+    "return-type": "json",
+    "interval": 15,
+    "signal": 6,
+    "on-click": "waybar-audio-speaker-menu",
+    "on-click-middle": "waybar-audio-speaker-toggle",
+    "on-click-right": "waybar-audio-speaker-toggle"
   },
 
   "custom/displays": {

--- a/nixosModules/sway/waybar/style.css
+++ b/nixosModules/sway/waybar/style.css
@@ -53,7 +53,9 @@ window#waybar {
 #custom-network-ethernet,
 #custom-network-vpn,
 #mode,
-#tray {
+#tray,
+#custom-audio-mic,
+#custom-audio-speaker {
   padding: 0 8pt;
 }
 
@@ -65,7 +67,11 @@ window#waybar {
 #custom-network-vpn.disconnected,
 #custom-network-wifi.disabled,
 #custom-network-ethernet.disabled,
-#custom-network-vpn.disabled {
+#custom-network-vpn.disabled,
+#custom-audio-mic.muted,
+#custom-audio-mic.disabled,
+#custom-audio-speaker.muted,
+#custom-audio-speaker.disabled {
   color: @insensitive_fg_color;
 }
 
@@ -126,6 +132,8 @@ window#waybar {
 #custom-power:hover,
 #custom-network-wifi:hover,
 #custom-network-ethernet:hover,
-#custom-network-vpn:hover {
+#custom-network-vpn:hover,
+#custom-audio-mic:hover,
+#custom-audio-speaker:hover {
   background-color: @borders;
 }

--- a/overlays/thoughtfull.nix
+++ b/overlays/thoughtfull.nix
@@ -201,6 +201,12 @@ in
       };
       pkgs = final;
     };
+    waybar-audio = import ../packages/waybar-audio.nix {
+      lib = {
+        inherit writeFileScriptBin;
+      };
+      pkgs = final;
+    };
     waybar-displays = import ../packages/waybar-displays.nix {
       lib = {
         inherit writeFileScriptBin;

--- a/packages/mic.nix
+++ b/packages/mic.nix
@@ -6,6 +6,7 @@ let
     pulseaudio
     replaceVars
     symlinkJoin
+    systemd
     ;
   inherit (lib) writeFileScriptBin;
   mic-mute-toggle = writeFileScriptBin {
@@ -13,6 +14,7 @@ let
     replacements = {
       DEFAULT_SOURCE = null;
       pactl = "${pulseaudio}/bin/pactl";
+      systemctl = "${systemd}/bin/systemctl";
       mic-status = "${mic-status}/bin/mic-status";
     };
     src = ./mic/mic-mute-toggle.bash;
@@ -56,6 +58,7 @@ let
       DEFAULT_SOURCE = null;
       canberra-gtk-play = "${libcanberra-gtk3}/bin/canberra-gtk-play";
       pactl = "${pulseaudio}/bin/pactl";
+      systemctl = "${systemd}/bin/systemctl";
       mic-status = "${mic-status}/bin/mic-status";
     };
     src = ./mic/mic-volume-down.bash;
@@ -66,6 +69,7 @@ let
       DEFAULT_SOURCE = null;
       canberra-gtk-play = "${libcanberra-gtk3}/bin/canberra-gtk-play";
       pactl = "${pulseaudio}/bin/pactl";
+      systemctl = "${systemd}/bin/systemctl";
       mic-status = "${mic-status}/bin/mic-status";
     };
     src = ./mic/mic-volume-up.bash;

--- a/packages/mic/mic-mute-toggle.bash
+++ b/packages/mic/mic-mute-toggle.bash
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 @pactl@ set-source-mute @DEFAULT_SOURCE@ toggle
 @mic-status@
+# See kanshi-active.bash for why this signals the unit rather than pkill -x waybar.
+@systemctl@ --user kill --signal=RTMIN+7 waybar.service || true

--- a/packages/mic/mic-volume-down.bash
+++ b/packages/mic/mic-volume-down.bash
@@ -3,3 +3,5 @@ set -euo pipefail
 @pactl@ set-source-volume @DEFAULT_SOURCE@ -5%
 @canberra-gtk-play@ --id=audio-volume-change || true
 @mic-status@
+# See kanshi-active.bash for why this signals the unit rather than pkill -x waybar.
+@systemctl@ --user kill --signal=RTMIN+7 waybar.service || true

--- a/packages/speaker.nix
+++ b/packages/speaker.nix
@@ -7,6 +7,7 @@ let
     pulseaudio
     replaceVars
     symlinkJoin
+    systemd
     ;
   inherit (lib) writeFileScriptBin;
   speaker-mute-toggle = writeFileScriptBin {
@@ -15,6 +16,7 @@ let
       DEFAULT_SINK = null;
       bash = "${bash}/bin/bash";
       pactl = "${pulseaudio}/bin/pactl";
+      systemctl = "${systemd}/bin/systemctl";
       speaker-status = "${speaker-status}/bin/speaker-status";
     };
     src = ./speaker/speaker-mute-toggle.bash;
@@ -60,6 +62,7 @@ let
       bash = "${bash}/bin/bash";
       canberra-gtk-play = "${libcanberra-gtk3}/bin/canberra-gtk-play";
       pactl = "${pulseaudio}/bin/pactl";
+      systemctl = "${systemd}/bin/systemctl";
       speaker-status = "${speaker-status}/bin/speaker-status";
     };
     src = ./speaker/speaker-volume-down.bash;
@@ -71,6 +74,7 @@ let
       bash = "${bash}/bin/bash";
       canberra-gtk-play = "${libcanberra-gtk3}/bin/canberra-gtk-play";
       pactl = "${pulseaudio}/bin/pactl";
+      systemctl = "${systemd}/bin/systemctl";
       speaker-status = "${speaker-status}/bin/speaker-status";
     };
     src = ./speaker/speaker-volume-up.bash;

--- a/packages/speaker/speaker-mute-toggle.bash
+++ b/packages/speaker/speaker-mute-toggle.bash
@@ -1,3 +1,5 @@
 #!@bash@
 @pactl@ set-sink-mute @DEFAULT_SINK@ toggle
 @speaker-status@
+# See kanshi-active.bash for why this signals the unit rather than pkill -x waybar.
+@systemctl@ --user kill --signal=RTMIN+6 waybar.service || true

--- a/packages/speaker/speaker-volume-up.bash
+++ b/packages/speaker/speaker-volume-up.bash
@@ -3,3 +3,5 @@ set -euo pipefail
 @pactl@ set-sink-volume @DEFAULT_SINK@ +5%
 @canberra-gtk-play@ --id=audio-volume-change || true
 @speaker-status@
+# See kanshi-active.bash for why this signals the unit rather than pkill -x waybar.
+@systemctl@ --user kill --signal=RTMIN+6 waybar.service || true

--- a/packages/waybar-audio.nix
+++ b/packages/waybar-audio.nix
@@ -1,0 +1,83 @@
+{ lib, pkgs, ... }:
+let
+  inherit (pkgs)
+    bash
+    fuzzel
+    jq
+    pulseaudio
+    symlinkJoin
+    systemd
+    ;
+  inherit (lib) writeFileScriptBin;
+  waybar-audio-speaker = writeFileScriptBin {
+    name = "waybar-audio-speaker";
+    replacements = {
+      bash = "${bash}/bin/bash";
+      jq = "${jq}/bin/jq";
+      pactl = "${pulseaudio}/bin/pactl";
+    };
+    src = ./waybar-audio/speaker-status.bash;
+  };
+  waybar-audio-speaker-menu = writeFileScriptBin {
+    name = "waybar-audio-speaker-menu";
+    replacements = {
+      bash = "${bash}/bin/bash";
+      fuzzel = "${fuzzel}/bin/fuzzel";
+      jq = "${jq}/bin/jq";
+      pactl = "${pulseaudio}/bin/pactl";
+      systemctl = "${systemd}/bin/systemctl";
+    };
+    src = ./waybar-audio/speaker-menu.bash;
+  };
+  waybar-audio-speaker-toggle = writeFileScriptBin {
+    name = "waybar-audio-speaker-toggle";
+    replacements = {
+      DEFAULT_SINK = null;
+      bash = "${bash}/bin/bash";
+      pactl = "${pulseaudio}/bin/pactl";
+      systemctl = "${systemd}/bin/systemctl";
+    };
+    src = ./waybar-audio/speaker-toggle.bash;
+  };
+  waybar-audio-mic = writeFileScriptBin {
+    name = "waybar-audio-mic";
+    replacements = {
+      bash = "${bash}/bin/bash";
+      jq = "${jq}/bin/jq";
+      pactl = "${pulseaudio}/bin/pactl";
+    };
+    src = ./waybar-audio/mic-status.bash;
+  };
+  waybar-audio-mic-menu = writeFileScriptBin {
+    name = "waybar-audio-mic-menu";
+    replacements = {
+      bash = "${bash}/bin/bash";
+      fuzzel = "${fuzzel}/bin/fuzzel";
+      jq = "${jq}/bin/jq";
+      pactl = "${pulseaudio}/bin/pactl";
+      systemctl = "${systemd}/bin/systemctl";
+    };
+    src = ./waybar-audio/mic-menu.bash;
+  };
+  waybar-audio-mic-toggle = writeFileScriptBin {
+    name = "waybar-audio-mic-toggle";
+    replacements = {
+      DEFAULT_SOURCE = null;
+      bash = "${bash}/bin/bash";
+      pactl = "${pulseaudio}/bin/pactl";
+      systemctl = "${systemd}/bin/systemctl";
+    };
+    src = ./waybar-audio/mic-toggle.bash;
+  };
+in
+symlinkJoin {
+  name = "waybar-audio";
+  paths = [
+    waybar-audio-mic
+    waybar-audio-mic-menu
+    waybar-audio-mic-toggle
+    waybar-audio-speaker
+    waybar-audio-speaker-menu
+    waybar-audio-speaker-toggle
+  ];
+}

--- a/packages/waybar-audio/mic-menu.bash
+++ b/packages/waybar-audio/mic-menu.bash
@@ -1,0 +1,33 @@
+#!@bash@
+set -euo pipefail
+
+# Fuzzel-driven picker for the Waybar custom/audio-mic widget's primary
+# click. Lists every input device (source), excluding sink monitors (a
+# monitor's "monitor_source" property points back at the sink it came from;
+# a real input device's is empty) -- those aren't microphones and pactl
+# itself would reject them as a set-default-source target. Once a source is
+# chosen, both sets it as the default *and* re-routes every currently
+# recording stream to it, matching the sink/speaker side of this widget.
+sources=$(@pactl@ -f json list sources 2>/dev/null) || sources="[]"
+sources=$(@jq@ -c '[.[] | select(.monitor_source == "")]' <<<"${sources}")
+mapfile -t names < <(@jq@ -r '.[].name' <<<"${sources}")
+mapfile -t descriptions < <(@jq@ -r '.[].description' <<<"${sources}")
+
+((${#names[@]} == 0)) && exit 0
+
+# See speaker-menu.bash/wifi-menu.bash for why a cancelled fuzzel must not
+# trip errexit here.
+index=$(printf '%s\n' "${descriptions[@]}" | @fuzzel@ --dmenu --minimal-lines --placeholder "Select input" --index) || exit 0
+[[ -z ${index} ]] && exit 0
+
+selected="${names[index]}"
+@pactl@ set-default-source "${selected}"
+
+mapfile -t outputs < <(@pactl@ list source-outputs short | cut -f1)
+for output in "${outputs[@]}"; do
+  [[ -z ${output} ]] && continue
+  @pactl@ move-source-output "${output}" "${selected}" || true
+done
+
+# See kanshi-active.bash for why this signals the unit rather than pkill -x waybar.
+@systemctl@ --user kill --signal=RTMIN+7 waybar.service || true

--- a/packages/waybar-audio/mic-status.bash
+++ b/packages/waybar-audio/mic-status.bash
@@ -1,0 +1,35 @@
+#!@bash@
+set -euo pipefail
+
+# Reports the default source's volume/mute state for the Waybar
+# custom/audio-mic widget. Polls on an interval and self-heals if a click
+# action's signal poke (see mic-menu.bash/mic-toggle.bash) is ever missed,
+# the same as waybar-network-wifi.
+default_source=$(@pactl@ get-default-source 2>/dev/null) || default_source=""
+sources=$(@pactl@ -f json list sources 2>/dev/null) || sources="[]"
+# shellcheck disable=SC2016
+source=$(@jq@ --arg name "${default_source}" '[.[] | select(.name == $name)][0] // empty' <<<"${sources}")
+
+if [[ -z ${default_source} || -z ${source} ]]; then
+  printf '{"text": "󰍭", "tooltip": "No microphone input available\\nClick to select input", "class": "disabled"}\n'
+  exit 0
+fi
+
+IFS=$'\t' read -r mute vol_percent desc < <(
+  @jq@ -r '[.mute, ([.volume[].value_percent][0] // "0%"), .description] | @tsv' <<<"${source}"
+)
+
+if [[ ${mute} == "true" ]]; then
+  icon="󰍭"
+  class="muted"
+  action="Right-click to unmute"
+else
+  icon="󰍬"
+  class="unmuted"
+  action="Right-click to mute"
+fi
+
+# shellcheck disable=SC2016
+@jq@ -cn --arg icon "${icon}" --arg desc "${desc}" --arg vol "${vol_percent}" \
+  --arg action "${action}" --arg class "${class}" \
+  '{text: $icon, tooltip: ($desc + ": " + $vol + "\nClick to select input\n" + $action), class: $class}'

--- a/packages/waybar-audio/mic-toggle.bash
+++ b/packages/waybar-audio/mic-toggle.bash
@@ -1,7 +1,5 @@
-#!/usr/bin/env bash
+#!@bash@
 set -euo pipefail
-@pactl@ set-source-volume @DEFAULT_SOURCE@ +5%
-@canberra-gtk-play@ --id=audio-volume-change || true
-@mic-status@
+@pactl@ set-source-mute @DEFAULT_SOURCE@ toggle
 # See kanshi-active.bash for why this signals the unit rather than pkill -x waybar.
 @systemctl@ --user kill --signal=RTMIN+7 waybar.service || true

--- a/packages/waybar-audio/speaker-menu.bash
+++ b/packages/waybar-audio/speaker-menu.bash
@@ -1,0 +1,34 @@
+#!@bash@
+set -euo pipefail
+
+# Fuzzel-driven picker for the Waybar custom/audio-speaker widget's primary
+# click. Lists every output device (sink) and, once one is chosen, both sets
+# it as the default *and* re-routes every currently-playing stream to it --
+# matching pavucontrol/GNOME's output-device picker, where switching output
+# while something is already playing actually moves the sound instead of
+# only affecting streams that start afterward.
+sinks=$(@pactl@ -f json list sinks 2>/dev/null) || sinks="[]"
+mapfile -t names < <(@jq@ -r '.[].name' <<<"${sinks}")
+mapfile -t descriptions < <(@jq@ -r '.[].description' <<<"${sinks}")
+
+((${#names[@]} == 0)) && exit 0
+
+# fuzzel exits non-zero (2 on Escape/right-click, 1 if dmenu mode never got
+# a selection) whenever nothing was chosen, which `errexit` would otherwise
+# treat as a script failure right at the assignment -- see wifi-menu.bash.
+index=$(printf '%s\n' "${descriptions[@]}" | @fuzzel@ --dmenu --minimal-lines --placeholder "Select output" --index) || exit 0
+[[ -z ${index} ]] && exit 0
+
+selected="${names[index]}"
+@pactl@ set-default-sink "${selected}"
+
+mapfile -t inputs < <(@pactl@ list sink-inputs short | cut -f1)
+for input in "${inputs[@]}"; do
+  [[ -z ${input} ]] && continue
+  @pactl@ move-sink-input "${input}" "${selected}" || true
+done
+
+# Signal the systemd unit directly rather than matching the process by name:
+# Nix wraps the waybar binary (for GTK/GIO env vars), so the actual running
+# process is named ".waybar-wrapped" on disk -- see kanshi-active.bash.
+@systemctl@ --user kill --signal=RTMIN+6 waybar.service || true

--- a/packages/waybar-audio/speaker-status.bash
+++ b/packages/waybar-audio/speaker-status.bash
@@ -1,0 +1,42 @@
+#!@bash@
+set -euo pipefail
+
+# Reports the default sink's volume/mute state for the Waybar
+# custom/audio-speaker widget. Polls on an interval and self-heals if a
+# click action's signal poke (see speaker-menu.bash/speaker-toggle.bash) is
+# ever missed, the same as waybar-network-wifi.
+default_sink=$(@pactl@ get-default-sink 2>/dev/null) || default_sink=""
+sinks=$(@pactl@ -f json list sinks 2>/dev/null) || sinks="[]"
+# shellcheck disable=SC2016
+sink=$(@jq@ --arg name "${default_sink}" '[.[] | select(.name == $name)][0] // empty' <<<"${sinks}")
+
+if [[ -z ${default_sink} || -z ${sink} ]]; then
+  printf '{"text": "󰝟", "tooltip": "No speaker output available\\nClick to select output", "class": "disabled"}\n'
+  exit 0
+fi
+
+IFS=$'\t' read -r mute vol_percent desc < <(
+  @jq@ -r '[.mute, ([.volume[].value_percent][0] // "0%"), .description] | @tsv' <<<"${sink}"
+)
+vol="${vol_percent%\%}"
+
+if [[ ${mute} == "true" ]]; then
+  icon="󰝟"
+  class="muted"
+  action="Right-click to unmute"
+else
+  if ((vol >= 65)); then
+    icon="󰕾"
+  elif ((vol >= 35)); then
+    icon="󰖀"
+  else
+    icon="󰕿"
+  fi
+  class="unmuted"
+  action="Right-click to mute"
+fi
+
+# shellcheck disable=SC2016
+@jq@ -cn --arg icon "${icon}" --arg desc "${desc}" --arg vol "${vol_percent}" \
+  --arg action "${action}" --arg class "${class}" \
+  '{text: $icon, tooltip: ($desc + ": " + $vol + "\nClick to select output\n" + $action), class: $class}'

--- a/packages/waybar-audio/speaker-toggle.bash
+++ b/packages/waybar-audio/speaker-toggle.bash
@@ -1,7 +1,5 @@
 #!@bash@
 set -euo pipefail
-@pactl@ set-sink-volume @DEFAULT_SINK@ -5%
-@canberra-gtk-play@ --id=audio-volume-change || true
-@speaker-status@
+@pactl@ set-sink-mute @DEFAULT_SINK@ toggle
 # See kanshi-active.bash for why this signals the unit rather than pkill -x waybar.
 @systemctl@ --user kill --signal=RTMIN+6 waybar.service || true

--- a/packages/waybar-displays.nix
+++ b/packages/waybar-displays.nix
@@ -3,8 +3,8 @@ let
   inherit (pkgs)
     bash
     kanshi
-    procps
     symlinkJoin
+    systemd
     ;
   inherit (lib) writeFileScriptBin;
   waybar-displays = writeFileScriptBin {
@@ -18,7 +18,7 @@ let
     name = "kanshi-active";
     replacements = {
       bash = "${bash}/bin/bash";
-      pkill = "${procps}/bin/pkill";
+      systemctl = "${systemd}/bin/systemctl";
     };
     src = ./waybar-displays/kanshi-active.bash;
   };

--- a/packages/waybar-displays/kanshi-active.bash
+++ b/packages/waybar-displays/kanshi-active.bash
@@ -8,6 +8,11 @@ dir="${XDG_RUNTIME_DIR:-/run/user/$UID}/kanshi"
 mkdir -p "$dir"
 printf '%s\n' "${1:-}" >"$dir/active-profile"
 
-# Refresh custom/displays (signal 4). Ignore failure so switching profiles still
-# works when Waybar isn't running.
-@pkill@ -RTMIN+4 waybar || true
+# Refresh custom/displays (signal 4) by signaling the systemd unit directly
+# rather than matching the process by name: Nix wraps the waybar binary (for
+# GTK/GIO env vars), so the actual running process is named ".waybar-wrapped"
+# on disk -- `pkill -x waybar` (or even an unanchored `pkill waybar`) is
+# fragile against that, while systemd already knows the unit's real PID(s)
+# regardless of what the wrapped binary calls itself. Ignore failure so
+# switching profiles still works when Waybar isn't running.
+@systemctl@ --user kill --signal=RTMIN+4 waybar.service || true

--- a/packages/waybar-network.nix
+++ b/packages/waybar-network.nix
@@ -7,7 +7,6 @@ let
     jq
     networkmanager
     networkmanagerapplet
-    procps
     symlinkJoin
     systemd
     ;
@@ -45,7 +44,7 @@ let
       bash = "${bash}/bin/bash";
       busctl = "${systemd}/bin/busctl";
       jq = "${jq}/bin/jq";
-      pkill = "${procps}/bin/pkill";
+      systemctl = "${systemd}/bin/systemctl";
       wifi-device = "${wifi-device}/bin/waybar-network-wifi-device";
     };
     src = ./waybar-network/wifi-toggle.bash;
@@ -55,7 +54,7 @@ let
     replacements = {
       bash = "${bash}/bin/bash";
       busctl = "${systemd}/bin/busctl";
-      pkill = "${procps}/bin/pkill";
+      systemctl = "${systemd}/bin/systemctl";
       wifi-device = "${wifi-device}/bin/waybar-network-wifi-device";
     };
     src = ./waybar-network/wifi-menu.bash;

--- a/packages/waybar-network/wifi-menu.bash
+++ b/packages/waybar-network/wifi-menu.bash
@@ -25,7 +25,7 @@ if [[ -n ${dev} && ${powered} != "true" ]]; then
   # iwmenu never even attempted -- fall through and let iwmenu try anyway,
   # same as if we hadn't powered on at all.
   @busctl@ --system set-property net.connman.iwd "${dev}" net.connman.iwd.Device Powered b true || true
-  @pkill@ -RTMIN+5 -x waybar || true
+  @systemctl@ --user kill --signal=RTMIN+5 waybar.service || true
   # Real hardware can take a few seconds to bring the interface up (driver
   # firmware load, etc.) before iwd registers the Station interface --
   # launching iwmenu before that happens makes it silently quit with no
@@ -46,4 +46,4 @@ if [[ -n ${dev} && ${powered} != "true" ]]; then
 fi
 
 iwmenu --launcher fuzzel || true
-@pkill@ -RTMIN+5 -x waybar || true
+@systemctl@ --user kill --signal=RTMIN+5 waybar.service || true

--- a/packages/waybar-network/wifi-toggle.bash
+++ b/packages/waybar-network/wifi-toggle.bash
@@ -31,12 +31,12 @@ powered="${fields[4]:-}"
 # nothing changed, which is accurate.
 if [[ ${powered} == "true" ]]; then
   @busctl@ --system set-property net.connman.iwd "${dev}" net.connman.iwd.Device Powered b false || true
-  @pkill@ -RTMIN+5 -x waybar || true
+  @systemctl@ --user kill --signal=RTMIN+5 waybar.service || true
   exit 0
 fi
 
 @busctl@ --system set-property net.connman.iwd "${dev}" net.connman.iwd.Device Powered b true || true
-@pkill@ -RTMIN+5 -x waybar || true
+@systemctl@ --user kill --signal=RTMIN+5 waybar.service || true
 for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
   @busctl@ --system get-property net.connman.iwd "${dev}" net.connman.iwd.Station Scanning &>/dev/null && break
   sleep 0.25
@@ -65,5 +65,5 @@ done < <(@jq@ -r '.data[0][][0] // empty' <<<"${ordered}" 2>/dev/null)
 
 if [[ -n ${best} ]]; then
   @busctl@ --system call net.connman.iwd "${best}" net.connman.iwd.Network Connect
-  @pkill@ -RTMIN+5 -x waybar || true
+  @systemctl@ --user kill --signal=RTMIN+5 waybar.service || true
 fi

--- a/tests/waybar.nix
+++ b/tests/waybar.nix
@@ -71,6 +71,72 @@ let
     };
     src = ../packages/waybar-network/ethernet-menu.bash;
   };
+
+  # Fixture-driven stand-in for pactl, used by the audio widget script tests
+  # below. Every invocation is logged (mirroring stubNmcli) so tests can
+  # assert on set-default-sink/move-sink-input calls without a real
+  # PipeWire/PulseAudio server; the handful of read commands the audio
+  # scripts depend on answer from files each subtest points at via env vars,
+  # so different subtests can swap in different fixtures without rebuilding
+  # the stub.
+  stubPactl = testPkgs.writeShellScriptBin "pactl" ''
+    set -euo pipefail
+    echo "pactl $*" >>/tmp/pactl-calls.log
+    case "$*" in
+      "-f json list sinks") cat "''${SINKS_JSON:-/dev/null}" ;;
+      "-f json list sources") cat "''${SOURCES_JSON:-/dev/null}" ;;
+      "get-default-sink") cat "''${DEFAULT_SINK_FILE:-/dev/null}" ;;
+      "get-default-source") cat "''${DEFAULT_SOURCE_FILE:-/dev/null}" ;;
+      "list sink-inputs short") cat "''${SINK_INPUTS:-/dev/null}" ;;
+      "list source-outputs short") cat "''${SOURCE_OUTPUTS:-/dev/null}" ;;
+      *) ;;
+    esac
+  '';
+
+  # The real status/menu scripts rebuilt with pactl/fuzzel replaced by the
+  # stubs above (jq and systemctl are the real thing -- deterministic and
+  # harmless against the test machine's real waybar service, same as the
+  # network widget tests leave them unstubbed).
+  testSpeakerStatus = testPkgs.thoughtfull.writeFileScriptBin {
+    name = "waybar-audio-speaker-test";
+    replacements = {
+      bash = "${testPkgs.bash}/bin/bash";
+      jq = "${testPkgs.jq}/bin/jq";
+      pactl = "${stubPactl}/bin/pactl";
+    };
+    src = ../packages/waybar-audio/speaker-status.bash;
+  };
+  testMicStatus = testPkgs.thoughtfull.writeFileScriptBin {
+    name = "waybar-audio-mic-test";
+    replacements = {
+      bash = "${testPkgs.bash}/bin/bash";
+      jq = "${testPkgs.jq}/bin/jq";
+      pactl = "${stubPactl}/bin/pactl";
+    };
+    src = ../packages/waybar-audio/mic-status.bash;
+  };
+  testSpeakerMenu = testPkgs.thoughtfull.writeFileScriptBin {
+    name = "waybar-audio-speaker-menu-test";
+    replacements = {
+      bash = "${testPkgs.bash}/bin/bash";
+      fuzzel = "${stubFuzzel}/bin/fuzzel";
+      jq = "${testPkgs.jq}/bin/jq";
+      pactl = "${stubPactl}/bin/pactl";
+      systemctl = "${testPkgs.systemd}/bin/systemctl";
+    };
+    src = ../packages/waybar-audio/speaker-menu.bash;
+  };
+  testMicMenu = testPkgs.thoughtfull.writeFileScriptBin {
+    name = "waybar-audio-mic-menu-test";
+    replacements = {
+      bash = "${testPkgs.bash}/bin/bash";
+      fuzzel = "${stubFuzzel}/bin/fuzzel";
+      jq = "${testPkgs.jq}/bin/jq";
+      pactl = "${stubPactl}/bin/pactl";
+      systemctl = "${testPkgs.systemd}/bin/systemctl";
+    };
+    src = ../packages/waybar-audio/mic-menu.bash;
+  };
 in
 testPkgs.testers.nixosTest {
   name = "waybar";
@@ -120,6 +186,10 @@ testPkgs.testers.nixosTest {
           pkgs.netcat
           pkgs.thoughtfull.waybar-displays
           testEthernetMenu
+          testMicMenu
+          testMicStatus
+          testSpeakerMenu
+          testSpeakerStatus
         ];
 
         # Create a test user for user services
@@ -162,6 +232,7 @@ testPkgs.testers.nixosTest {
 
   testScript = ''
     import json
+    import shlex
 
     start_all()
     machine.wait_for_unit("multi-user.target")
@@ -344,17 +415,17 @@ testPkgs.testers.nixosTest {
         # gtk-defaults sets the GTK icon theme via gsettings. Rather than
         # every consumer ordering after gtk-defaults.service individually,
         # sway-session.target itself waits on it, so anything that just waits
-        # on the target (waybar, pasystray, blueman-applet, ...) is covered.
-        # Absence of a cycle above isn't enough to prove this edge exists --
-        # e.g. a consumer silently losing its after=sway-session.target
-        # wouldn't cycle, just quietly reintroduce the race -- so assert the
-        # ordering direction directly on the rendered unit.
+        # on the target (waybar, blueman-applet, ...) is covered. Absence of
+        # a cycle above isn't enough to prove this edge exists -- e.g. a
+        # consumer silently losing its after=sway-session.target wouldn't
+        # cycle, just quietly reintroduce the race -- so assert the ordering
+        # direction directly on the rendered unit.
         target_unit = machine.succeed("cat /etc/systemd/user/sway-session.target")
         assert "gtk-defaults.service" in target_unit, (
             "sway-session.target should be ordered After=gtk-defaults.service"
         )
 
-    with subtest("waybar and pasystray are ordered after sway-session.target"):
+    with subtest("waybar is ordered after sway-session.target"):
         # Same reasoning as above: confirm the consumer side of the edge
         # directly, rather than relying only on cycle-absence.
         dropin = machine.succeed("cat /etc/systemd/user/waybar.service.d/*.conf")
@@ -362,13 +433,14 @@ testPkgs.testers.nixosTest {
             "waybar should be ordered After=sway-session.target"
         )
 
-        pasystray_unit = machine.succeed("cat /etc/systemd/user/pasystray.service")
-        assert "sway-session.target" in pasystray_unit, (
-            "pasystray should be ordered After=sway-session.target"
-        )
-
     with subtest("nm-applet is removed"):
         machine.fail("test -f /etc/systemd/user/nm-applet.service")
+
+    with subtest("pasystray is not installed or managed"):
+        # Replaced by the custom/audio-mic and custom/audio-speaker widgets
+        # below -- no tray icon, no user service, no package.
+        machine.fail("test -f /etc/systemd/user/pasystray.service")
+        machine.fail("command -v pasystray")
 
     with subtest("waybar config wires up the network widgets"):
         # Replaces nm-applet's tray icon with three custom modules: Wi-Fi,
@@ -427,6 +499,53 @@ testPkgs.testers.nixosTest {
             'grep -q \'"on-click-right": "waybar-network-vpn-toggle"\' /etc/xdg/waybar/config.jsonc'
         )
 
+    with subtest("waybar config wires up the audio widgets"):
+        # Replaces pasystray's tray icon with two custom modules: mic and
+        # speaker. Placed after the network widgets, before tray -- the slot
+        # the old pasystray tray icon occupied.
+        config = machine.succeed("cat /etc/xdg/waybar/config.jsonc")
+        for module in ["custom/audio-mic", "custom/audio-speaker"]:
+            assert f'"{module}"' in config, f"{module} missing from config.jsonc"
+
+        assert (
+            config.index('"custom/network-vpn"')
+            < config.index('"custom/audio-mic"')
+            < config.index('"tray"')
+        ), "audio widgets should sit between the network widgets and tray"
+
+        for module in ["custom/audio-mic", "custom/audio-speaker"]:
+            block = config[config.index(f'"{module}": {{') :]
+            block = block[: block.index("\n  },")]
+            assert '"format": "<span font=\\"20px\\">{}</span>"' in block, (
+                f"{module} should use the same 20px icon format as theme/power"
+            )
+
+        machine.succeed('grep -q \'"exec": "waybar-audio-mic"\' /etc/xdg/waybar/config.jsonc')
+        # mic-menu.bash and mic-toggle.bash both poke this signal after
+        # changing state, so the icon updates immediately instead of
+        # waiting out the 15s poll interval.
+        machine.succeed('grep -q \'"signal": 7\' /etc/xdg/waybar/config.jsonc')
+        machine.succeed(
+            'grep -q \'"on-click": "waybar-audio-mic-menu"\' /etc/xdg/waybar/config.jsonc'
+        )
+        machine.succeed(
+            'grep -q \'"on-click-middle": "waybar-audio-mic-toggle"\' /etc/xdg/waybar/config.jsonc'
+        )
+        machine.succeed(
+            'grep -q \'"on-click-right": "waybar-audio-mic-toggle"\' /etc/xdg/waybar/config.jsonc'
+        )
+        machine.succeed('grep -q \'"exec": "waybar-audio-speaker"\' /etc/xdg/waybar/config.jsonc')
+        machine.succeed('grep -q \'"signal": 6\' /etc/xdg/waybar/config.jsonc')
+        machine.succeed(
+            'grep -q \'"on-click": "waybar-audio-speaker-menu"\' /etc/xdg/waybar/config.jsonc'
+        )
+        machine.succeed(
+            'grep -q \'"on-click-middle": "waybar-audio-speaker-toggle"\' /etc/xdg/waybar/config.jsonc'
+        )
+        machine.succeed(
+            'grep -q \'"on-click-right": "waybar-audio-speaker-toggle"\' /etc/xdg/waybar/config.jsonc'
+        )
+
     with subtest("waybar service PATH provides the network widgets' tooling"):
         # PATH= only lists directories (nix store paths), one per package --
         # individual binary names inside a symlinkJoin bundle (like the six
@@ -440,6 +559,11 @@ testPkgs.testers.nixosTest {
             "network-manager-applet",
             "waybar-network",
         ]:
+            assert tool in dropin, f"{tool} missing from waybar PATH"
+
+    with subtest("waybar service PATH provides the audio widgets' tooling"):
+        dropin = machine.succeed("cat /etc/systemd/user/waybar.service.d/*.conf")
+        for tool in ["fuzzel", "pulseaudio", "waybar-audio"]:
             assert tool in dropin, f"{tool} missing from waybar PATH"
 
     with subtest("network widgets use icon padding and no active background"):
@@ -461,6 +585,16 @@ testPkgs.testers.nixosTest {
         assert "#custom-network-vpn.connected" not in style, (
             "VPN should use the normal background when connected"
         )
+
+    with subtest("audio widgets use the default padding and dim when muted/disabled"):
+        style = machine.succeed("cat /etc/xdg/waybar/style.css")
+        assert "#custom-audio-mic,\n#custom-audio-speaker" in style, (
+            "audio widgets should use the default network widget padding"
+        )
+        assert "#custom-audio-mic.muted" in style, "muted mic should be dimmed"
+        assert "#custom-audio-speaker.muted" in style, "muted speaker should be dimmed"
+        assert "#custom-audio-mic.disabled" in style, "disabled mic should be dimmed"
+        assert "#custom-audio-speaker.disabled" in style, "disabled speaker should be dimmed"
 
     with subtest("waybar-network-wifi reports a disabled state when iwd is unavailable"):
         # This test node doesn't enable networking.wireless.iwd, so there's
@@ -586,5 +720,158 @@ testPkgs.testers.nixosTest {
         status = json.loads(out)
         assert status["class"] == "disconnected", f"expected disconnected again, got: {out}"
         assert status["text"] == "󰦝", f"expected icon-only VPN text, got: {out}"
+
+    with subtest("waybar-audio-speaker reports volume level, mute, and disabled state"):
+        # Exercises the real speaker-status.bash logic (waybar-audio-speaker-test,
+        # built from the same source as waybar-audio-speaker but with pactl
+        # replaced by stubPactl) against fixture pactl output, without a real
+        # PipeWire/PulseAudio server.
+        def sink_fixture(mute, volume_percent):
+            return json.dumps(
+                [
+                    {
+                        "name": "sink1",
+                        "description": "Built-in Speakers",
+                        "mute": mute,
+                        "volume": {"front-left": {"value_percent": f"{volume_percent}%"}},
+                    }
+                ]
+            )
+
+        def speaker_status(default_sink, sinks_json):
+            machine.succeed(f"printf '%s' {shlex.quote(default_sink)} >/tmp/default-sink")
+            machine.succeed(f"printf '%s' {shlex.quote(sinks_json)} >/tmp/sinks.json")
+            out = machine.succeed(
+                "DEFAULT_SINK_FILE=/tmp/default-sink SINKS_JSON=/tmp/sinks.json "
+                "waybar-audio-speaker-test"
+            ).strip()
+            return json.loads(out)
+
+        status = speaker_status("sink1", sink_fixture(False, 80))
+        assert status["class"] == "unmuted", f"expected unmuted, got: {status}"
+        assert status["text"] == "󰕾", f"expected the high-volume icon, got: {status}"
+        assert "80%" in status["tooltip"], f"expected volume in tooltip, got: {status}"
+
+        status = speaker_status("sink1", sink_fixture(False, 20))
+        assert status["text"] == "󰕿", f"expected the low-volume icon, got: {status}"
+
+        status = speaker_status("sink1", sink_fixture(True, 80))
+        assert status["class"] == "muted", f"expected muted, got: {status}"
+        assert status["text"] == "󰝟", f"expected the muted icon, got: {status}"
+
+        status = speaker_status("", "[]")
+        assert status["class"] == "disabled", f"expected disabled, got: {status}"
+        assert status["text"] == "󰝟", f"expected the muted-style icon for disabled, got: {status}"
+
+    with subtest("waybar-audio-mic reports volume level, mute, and disabled state"):
+        def source_fixture(mute, volume_percent):
+            return json.dumps(
+                [
+                    {
+                        "name": "source1",
+                        "description": "Built-in Microphone",
+                        "mute": mute,
+                        "volume": {"front-left": {"value_percent": f"{volume_percent}%"}},
+                        "monitor_source": "",
+                    }
+                ]
+            )
+
+        def mic_status(default_source, sources_json):
+            machine.succeed(f"printf '%s' {shlex.quote(default_source)} >/tmp/default-source")
+            machine.succeed(f"printf '%s' {shlex.quote(sources_json)} >/tmp/sources.json")
+            out = machine.succeed(
+                "DEFAULT_SOURCE_FILE=/tmp/default-source SOURCES_JSON=/tmp/sources.json "
+                "waybar-audio-mic-test"
+            ).strip()
+            return json.loads(out)
+
+        status = mic_status("source1", source_fixture(False, 80))
+        assert status["class"] == "unmuted", f"expected unmuted, got: {status}"
+        assert status["text"] == "󰍬", f"expected the microphone icon, got: {status}"
+        assert "80%" in status["tooltip"], f"expected volume in tooltip, got: {status}"
+
+        status = mic_status("source1", source_fixture(True, 80))
+        assert status["class"] == "muted", f"expected muted, got: {status}"
+        assert status["text"] == "󰍭", f"expected the muted-microphone icon (no dots), got: {status}"
+
+        status = mic_status("", "[]")
+        assert status["class"] == "disabled", f"expected disabled, got: {status}"
+        assert status["text"] == "󰍭", f"expected the muted-style icon for disabled, got: {status}"
+
+    with subtest("waybar-audio-speaker-menu switches the default sink and reroutes active streams"):
+        # Exercises the real speaker-menu.bash logic (waybar-audio-speaker-menu-test,
+        # built with pactl/fuzzel replaced by stubPactl/stubFuzzel) against
+        # fixture pactl output and a scripted fuzzel selection.
+        machine.succeed("rm -f /tmp/pactl-calls.log /tmp/fuzzel-menu.log")
+        sinks = json.dumps(
+            [
+                {"name": "sink1", "description": "Speakers"},
+                {"name": "sink2", "description": "Headphones"},
+            ]
+        )
+        machine.succeed(f"printf '%s' {shlex.quote(sinks)} >/tmp/sinks.json")
+        # One already-playing stream (sink-input index 42), currently on sink1.
+        machine.succeed("printf '42\\tsink1\\t7\\t4294967295\\tfloat32le 2ch 48000Hz\\n' >/tmp/sink-inputs")
+        machine.succeed("printf '2\\n' >/tmp/fuzzel-answers")
+
+        machine.succeed(
+            "FUZZEL_LOG=/tmp/fuzzel-menu.log FUZZEL_ANSWERS=/tmp/fuzzel-answers "
+            "SINKS_JSON=/tmp/sinks.json SINK_INPUTS=/tmp/sink-inputs "
+            "waybar-audio-speaker-menu-test"
+        )
+
+        fuzzel_log = machine.succeed("cat /tmp/fuzzel-menu.log")
+        assert "Speakers" in fuzzel_log and "Headphones" in fuzzel_log, (
+            f"expected both sink descriptions in the fuzzel menu, got: {fuzzel_log}"
+        )
+
+        calls = machine.succeed("cat /tmp/pactl-calls.log")
+        assert "set-default-sink sink2" in calls, (
+            f"expected the second (Headphones) sink to become default, got: {calls}"
+        )
+        assert "move-sink-input 42 sink2" in calls, (
+            f"expected the active stream to be rerouted to the new default, got: {calls}"
+        )
+
+    with subtest("waybar-audio-mic-menu switches the default source, reroutes streams, and hides monitors"):
+        machine.succeed("rm -f /tmp/pactl-calls.log /tmp/fuzzel-menu.log")
+        sources = json.dumps(
+            [
+                {"name": "source1", "description": "Built-in Microphone", "monitor_source": ""},
+                {"name": "source2", "description": "USB Headset Mic", "monitor_source": ""},
+                # A sink's monitor -- must never appear as an input choice.
+                {
+                    "name": "sink1.monitor",
+                    "description": "Monitor of Speakers",
+                    "monitor_source": "sink1",
+                },
+            ]
+        )
+        machine.succeed(f"printf '%s' {shlex.quote(sources)} >/tmp/sources.json")
+        machine.succeed("printf '9\\tsource1\\t3\\t4294967295\\tfloat32le 1ch 48000Hz\\n' >/tmp/source-outputs")
+        machine.succeed("printf '2\\n' >/tmp/fuzzel-answers")
+
+        machine.succeed(
+            "FUZZEL_LOG=/tmp/fuzzel-menu.log FUZZEL_ANSWERS=/tmp/fuzzel-answers "
+            "SOURCES_JSON=/tmp/sources.json SOURCE_OUTPUTS=/tmp/source-outputs "
+            "waybar-audio-mic-menu-test"
+        )
+
+        fuzzel_log = machine.succeed("cat /tmp/fuzzel-menu.log")
+        assert "Built-in Microphone" in fuzzel_log and "USB Headset Mic" in fuzzel_log, (
+            f"expected both real input descriptions in the fuzzel menu, got: {fuzzel_log}"
+        )
+        assert "Monitor of Speakers" not in fuzzel_log, (
+            f"a sink monitor should never be offered as an input, got: {fuzzel_log}"
+        )
+
+        calls = machine.succeed("cat /tmp/pactl-calls.log")
+        assert "set-default-source source2" in calls, (
+            f"expected the second (USB Headset Mic) source to become default, got: {calls}"
+        )
+        assert "move-source-output 9 source2" in calls, (
+            f"expected the active recording to be rerouted to the new default, got: {calls}"
+        )
   '';
 }


### PR DESCRIPTION
## Summary
- Replace pasystray's static tray icon with two custom Waybar modules, `custom/audio-mic` and `custom/audio-speaker`, backed by a new `waybar-audio` package: each reports mute state via `pactl`, opens a fuzzel picker on click to switch the default input/output device (rerouting already-playing streams to it), and toggles mute on right/middle-click.
- Fixes a latent bug found while wiring up signal-based refresh for the new widgets: Nix wraps the `waybar` binary for GTK/GIO env vars, so the real process is named `.waybar-wrapped` on disk, and `pkill -x waybar` never actually matched it. Every custom module's "refresh now" signal (Wi-Fi, displays, and the new audio ones) was silently falling back to plain interval polling. Switched all of them to `systemctl --user kill --signal=RTMIN+N waybar.service`, which targets the unit directly regardless of the wrapped process's name.
- Wired the physical mic/speaker media-key scripts to poke the same refresh signals so the widgets update instantly instead of waiting out the poll interval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)