### PR TITLE
Add minecraft module and enable on hydor

### DIFF
--- a/nixosConfigurations/hydor.nix
+++ b/nixosConfigurations/hydor.nix
@@ -31,6 +31,7 @@
             encrypted.device = "/dev/nvme0n1";
             swap.size = "4G";
           };
+          programs.minecraft.enable = true;
           user.hashedPasswordFile = ./hydor/secrets/hashed-user-passphrase.age;
           vpn.configFile = ./hydor/secrets/vpn-config.age;
         };

--- a/nixosModules/default.nix
+++ b/nixosModules/default.nix
@@ -73,6 +73,7 @@ in
     ./javascript.nix
     ./less.nix
     ./mako.nix
+    ./minecraft.nix
     ./monitoring.nix
     ./obsidian.nix
     ./openssh.nix

--- a/nixosModules/minecraft.nix
+++ b/nixosModules/minecraft.nix
@@ -1,0 +1,25 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (config.thoughtfull.programs) minecraft;
+  inherit (lib) mkEnableOption mkIf;
+in
+{
+  config = mkIf minecraft.enable {
+    environment.systemPackages = [ pkgs.hmcl ];
+    thoughtfull.impermanence.user = {
+      directories = [
+        ".local/share/hmcl"
+        ".minecraft"
+      ];
+      files = [
+        ".hmcl/hmcl.json"
+      ];
+    };
+  };
+  options.thoughtfull.programs.minecraft.enable = mkEnableOption "minecraft";
+}

--- a/nixosModules/minecraft.nix
+++ b/nixosModules/minecraft.nix
@@ -13,11 +13,19 @@ in
     environment.systemPackages = [ pkgs.hmcl ];
     thoughtfull.impermanence.user = {
       directories = [
-        ".local/share/hmcl"
+        {
+          directory = ".local/share/hmcl";
+          mode = "0700";
+        }
         ".minecraft"
       ];
       files = [
-        ".hmcl/hmcl.json"
+        {
+          file = ".hmcl/hmcl.json";
+          parentDirectory = {
+            mode = "0700";
+          };
+        }
       ];
     };
   };


### PR DESCRIPTION
## Summary
- Add a `minecraft` module (`thoughtfull.programs.minecraft.enable`) that installs HMCL and persists its state through impermanence (`~/.local/share/hmcl`, `~/.minecraft`, `~/.hmcl/hmcl.json`)
- Enable the module on hydor

🤖 Generated with [Claude Code](https://claude.com/claude-code)