### PR TITLE
Stop restic backup before system sleep

### DIFF
--- a/nixosModules/restic.nix
+++ b/nixosModules/restic.nix
@@ -1,4 +1,9 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   inherit (config.age.secrets) resticEnvironment resticPassword resticRepository;
   inherit (config.services.restic.thoughtfull)
@@ -42,6 +47,15 @@ in
       timerConfig = {
         OnCalendar = "hourly";
         Persistent = true;
+      };
+    };
+    systemd.services.restic-stop-before-sleep = {
+      description = "Stop restic backup before sleep to avoid an orphaned repo lock breaking backups on other hosts";
+      before = [ "sleep.target" ];
+      wantedBy = [ "sleep.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.systemd}/bin/systemctl stop restic-backups-default.service";
       };
     };
   };

--- a/tests.nix
+++ b/tests.nix
@@ -25,6 +25,7 @@ forEachSystem (
     kanshi = callTest ./tests/kanshi.nix;
     monitoring = callTest ./tests/monitoring.nix;
     nixfiles = callTest ./tests/nixfiles.nix;
+    restic = callTest ./tests/restic.nix;
     system-pull = callTest ./tests/system-pull.nix;
     vpn = callTest ./tests/vpn.nix;
     waybar = callTest ./tests/waybar.nix;

--- a/tests/restic.nix
+++ b/tests/restic.nix
@@ -1,0 +1,78 @@
+{ nixpkgs, ... }:
+let
+  # Stub the agenix `age.secrets` option so we can test the module's
+  # systemd wiring without actually pulling in the agenix activation
+  # scripts (which need a real SSH identity to decrypt).
+  ageSecretsStub =
+    { lib, ... }:
+    {
+      options.age.secrets = lib.mkOption {
+        default = { };
+        type = lib.types.attrsOf (
+          lib.types.submodule (
+            { name, ... }:
+            {
+              options = {
+                file = lib.mkOption { type = lib.types.path; };
+                mode = lib.mkOption {
+                  type = lib.types.str;
+                  default = "0400";
+                };
+                path = lib.mkOption {
+                  type = lib.types.str;
+                  default = "/run/agenix/${name}";
+                };
+              };
+            }
+          )
+        );
+      };
+    };
+in
+nixpkgs.testers.nixosTest {
+  name = "restic";
+
+  skipTypeCheck = true;
+  skipLint = true;
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [
+        ../nixosModules/restic.nix
+        ageSecretsStub
+      ];
+      services.restic.thoughtfull = {
+        enable = true;
+        environmentFile = pkgs.writeText "fake-restic-environment" "";
+        passwordFile = pkgs.writeText "fake-restic-password" "fake-password";
+        repositoryFile = pkgs.writeText "fake-restic-repository" "/tmp/restic-repo";
+      };
+    };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("restic-stop-before-sleep is ordered before sleep.target"):
+        before = machine.succeed(
+            "systemctl show restic-stop-before-sleep.service --property=Before --value"
+        )
+        print(f"Before={before}")
+        assert "sleep.target" in before, "expected Before= to include sleep.target"
+
+    with subtest("restic-stop-before-sleep is wanted by sleep.target"):
+        machine.succeed(
+            "test -L /etc/systemd/system/sleep.target.wants/restic-stop-before-sleep.service"
+        )
+
+    with subtest("restic-stop-before-sleep stops the restic backup service"):
+        exec_start = machine.succeed(
+            "systemctl show restic-stop-before-sleep.service --property=ExecStart --value"
+        )
+        print(f"ExecStart={exec_start}")
+        assert "restic-backups-default.service" in exec_start, (
+            "expected ExecStart to stop restic-backups-default.service"
+        )
+  '';
+}


### PR DESCRIPTION
## Summary
- Suspending mid-backup can kill the restic process without releasing its repository lock, causing backups on other machines to fail
- Add a `restic-stop-before-sleep` systemd unit ordered before `sleep.target` that stops the backup service, letting restic catch `SIGTERM` and unlock cleanly before suspend proceeds
- Add `tests/restic.nix` verifying the unit's ordering, `sleep.target` wants relationship, and that it stops `restic-backups-default.service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)