### PR TITLE
Scope sway workspaces per output and pin aegle assignments

### DIFF
--- a/nixosConfigurations/aegle.nix
+++ b/nixosConfigurations/aegle.nix
@@ -14,6 +14,7 @@
         # blacklisting `option` lets the camera bind correctly.
         boot.blacklistedKernelModules = [ "option" ];
         environment = {
+          etc."sway/config.d/workspaces.conf".source = ./aegle/sway/workspaces.conf;
           systemPackages = with pkgs; [
             libreoffice
             maven

--- a/nixosConfigurations/aegle/sway/workspaces.conf
+++ b/nixosConfigurations/aegle/sway/workspaces.conf
@@ -1,0 +1,9 @@
+# Pin workspaces to outputs. Identifiers match aegle/kanshi/config: the external
+# monitor by its `make model serial`, the laptop panel by its stable eDP-1 name.
+# Workspaces 1-3 live on the external monitor, workspace 4 on the laptop. The
+# second output on each line is a fallback for when the external monitor is
+# absent (undocked), so every workspace still lands on the laptop.
+workspace 1 output "ICB HDMI ICB UHD 60" eDP-1
+workspace 2 output "ICB HDMI ICB UHD 60" eDP-1
+workspace 3 output "ICB HDMI ICB UHD 60" eDP-1
+workspace 4 output eDP-1 "ICB HDMI ICB UHD 60"

--- a/nixosModules/sway/config
+++ b/nixosModules/sway/config
@@ -106,6 +106,12 @@ set $menu fuzzel
     bindsym $mod+Shift+Down move down
     bindsym $mod+Shift+Up move up
     bindsym $mod+Shift+Right move right
+
+    # Move the whole current workspace to the output in the given direction.
+    # With two monitors this acts as "send this workspace to the other screen";
+    # sway does not wrap, so the direction with no output that way is a no-op.
+    bindsym $mod+Mod1+b move workspace to output left
+    bindsym $mod+Mod1+f move workspace to output right
 #
 # Workspaces:
 #

--- a/nixosModules/sway/waybar/config.jsonc
+++ b/nixosModules/sway/waybar/config.jsonc
@@ -10,7 +10,7 @@
 
   "sway/workspaces": {
     "disable-scroll": false,
-    "all-outputs": true,
+    "all-outputs": false,
     "format": "{name}"
   },
 


### PR DESCRIPTION
Set waybar all-outputs to false so each monitor's bar shows only the workspaces living on that output, instead of every workspace with the globally-focused one highlighted on both bars.

Add $mod+Alt+b/f bindings to move the current workspace to the output to the left/right, matching the existing emacs-style directional bindings.

Pin aegle's workspaces 1-3 to the external monitor and 4 to the laptop panel, with the opposite output as fallback for when undocked.