### PR TITLE
Add minecraft-server module and enable on tislit

### DIFF
--- a/nixosConfigurations/tislit.nix
+++ b/nixosConfigurations/tislit.nix
@@ -13,6 +13,7 @@
         networking.hostName = "tislit";
         services = {
           emacs.enable = true;
+          minecraft-server.package = pkgs.thoughtfull.papermc-26-2;
           openssh.enable = true;
           restic.thoughtfull.enable = true;
           syncthing = {
@@ -36,6 +37,7 @@
             };
           };
           rpi4.enable = true;
+          services.minecraft-server.enable = true;
           user = {
             extraGroups = [ "wheel" ];
             hashedPasswordFile = ./tislit/secrets/hashed-user-passphrase.age;

--- a/nixosConfigurations/tislit.nix
+++ b/nixosConfigurations/tislit.nix
@@ -13,7 +13,10 @@
         networking.hostName = "tislit";
         services = {
           emacs.enable = true;
-          minecraft-server.package = pkgs.thoughtfull.papermc-26-2;
+          minecraft-server = {
+            enable = true;
+            jvmOpts = "-Xmx3072M -Xms3072M";
+          };
           openssh.enable = true;
           restic.thoughtfull.enable = true;
           syncthing = {
@@ -37,7 +40,6 @@
             };
           };
           rpi4.enable = true;
-          services.minecraft-server.enable = true;
           user = {
             extraGroups = [ "wheel" ];
             hashedPasswordFile = ./tislit/secrets/hashed-user-passphrase.age;

--- a/nixosModules/default.nix
+++ b/nixosModules/default.nix
@@ -73,6 +73,7 @@ in
     ./javascript.nix
     ./less.nix
     ./mako.nix
+    ./minecraft-server.nix
     ./minecraft.nix
     ./monitoring.nix
     ./obsidian.nix

--- a/nixosModules/minecraft-server.nix
+++ b/nixosModules/minecraft-server.nix
@@ -1,0 +1,44 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (config.thoughtfull.services) minecraft-server;
+  inherit (lib)
+    mkDefault
+    mkEnableOption
+    mkIf
+    ;
+in
+{
+  config = mkIf minecraft-server.enable {
+    services.minecraft-server = {
+      declarative = mkDefault true;
+      enable = mkDefault true;
+      eula = mkDefault true;
+      jvmOpts = "-Xmx3072M -Xms3072M";
+      openFirewall = mkDefault true;
+      package = mkDefault pkgs.papermc;
+      serverProperties = {
+        difficulty = mkDefault 2;
+        gamemode = mkDefault 0;
+        max-players = mkDefault 5;
+        motd = mkDefault "Survive and thrive!";
+        server-port = mkDefault 25565;
+        simulation-distance = mkDefault 4;
+        view-distance = mkDefault 6;
+      };
+    };
+    thoughtfull.impermanence.directories = [
+      {
+        directory = config.services.minecraft-server.dataDir;
+        mode = "0750";
+        group = "minecraft";
+        user = "minecraft";
+      }
+    ];
+  };
+  options.thoughtfull.services.minecraft-server.enable = mkEnableOption "minecraft-server";
+}

--- a/nixosModules/minecraft-server.nix
+++ b/nixosModules/minecraft-server.nix
@@ -18,7 +18,7 @@ in
       declarative = mkDefault true;
       enable = mkDefault true;
       eula = mkDefault true;
-      jvmOpts = "-Xmx3072M -Xms3072M";
+      jvmOpts = mkDefault "-Xmx3072M -Xms3072M";
       openFirewall = mkDefault true;
       package = mkDefault pkgs.papermc;
       serverProperties = {

--- a/nixosModules/minecraft-server.nix
+++ b/nixosModules/minecraft-server.nix
@@ -5,10 +5,9 @@
   ...
 }:
 let
-  inherit (config.thoughtfull.services) minecraft-server;
+  inherit (config.services) minecraft-server;
   inherit (lib)
     mkDefault
-    mkEnableOption
     mkIf
     ;
 in
@@ -16,11 +15,9 @@ in
   config = mkIf minecraft-server.enable {
     services.minecraft-server = {
       declarative = mkDefault true;
-      enable = mkDefault true;
       eula = mkDefault true;
-      jvmOpts = mkDefault "-Xmx3072M -Xms3072M";
       openFirewall = mkDefault true;
-      package = mkDefault pkgs.papermc;
+      package = mkDefault pkgs.thoughtfull.papermc-26-2;
       serverProperties = {
         difficulty = mkDefault 2;
         gamemode = mkDefault 0;
@@ -40,5 +37,4 @@ in
       }
     ];
   };
-  options.thoughtfull.services.minecraft-server.enable = mkEnableOption "minecraft-server";
 }

--- a/overlays/thoughtfull.nix
+++ b/overlays/thoughtfull.nix
@@ -147,6 +147,9 @@ in
       }
     );
     options-doc = import ../packages/options-doc (self // { pkgs = final; });
+    papermc-26-2 = import ../packages/papermc-26-2.nix {
+      pkgs = final;
+    };
     pins = import ../packages/pins.nix {
       lib = {
         inherit writeFileScriptBin;

--- a/packages/papermc-26-2.nix
+++ b/packages/papermc-26-2.nix
@@ -1,0 +1,59 @@
+{ pkgs, ... }:
+let
+  inherit (pkgs)
+    fetchurl
+    jdk25
+    makeBinaryWrapper
+    stdenvNoCC
+    udev
+    ;
+  inherit (pkgs.lib)
+    getExe
+    makeLibraryPath
+    licenses
+    optionalString
+    platforms
+    ;
+in
+# nixpkgs' papermc is stuck on 1.21.11: its update.py targets the sunset PaperMC v2 API, so it
+# can't see builds published under Minecraft/Paper's newer date-based versioning (26.x) via the
+# v3/fill API. Tracked upstream at https://github.com/NixOS/nixpkgs/issues/527546. Delete this
+# package and switch back to pkgs.papermc once that lands.
+#
+# Paper 26.x also requires running with Java 25+, unlike nixpkgs' papermc which wraps the
+# default (older) jre.
+stdenvNoCC.mkDerivation {
+  pname = "papermc";
+  version = "26.2-63";
+
+  src = fetchurl {
+    url = "https://fill-data.papermc.io/v1/objects/3f79f638434eb004a2d2ae7cc23235a6f95ca94e18480f05280bb9728bf1e8cf/paper-26.2-63.jar";
+    hash = "sha256-P3n2OENOsASi0q58wjI1pvlcqU4YSA8FKAu5covx6M8=";
+  };
+
+  dontUnpack = true;
+  preferLocalBuild = true;
+  allowSubstitutes = false;
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D $src $out/share/papermc/papermc.jar
+
+    makeWrapper ${getExe jdk25} "$out/bin/minecraft-server" \
+      --append-flags "-jar $out/share/papermc/papermc.jar nogui" \
+      ${optionalString stdenvNoCC.hostPlatform.isLinux "--prefix LD_LIBRARY_PATH : ${makeLibraryPath [ udev ]}"}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "High-performance Minecraft server, pinned to Paper 26.2 build 63";
+    homepage = "https://papermc.io/";
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+    mainProgram = "minecraft-server";
+  };
+}

--- a/tests.nix
+++ b/tests.nix
@@ -23,6 +23,7 @@ forEachSystem (
     github-token = callTest ./tests/github-token.nix;
     graphical = callTest ./tests/graphical.nix;
     kanshi = callTest ./tests/kanshi.nix;
+    minecraft-server = callTest ./tests/minecraft-server.nix;
     monitoring = callTest ./tests/monitoring.nix;
     nixfiles = callTest ./tests/nixfiles.nix;
     restic = callTest ./tests/restic.nix;

--- a/tests/minecraft-server.nix
+++ b/tests/minecraft-server.nix
@@ -30,7 +30,7 @@ nixpkgs.testers.nixosTest {
           ../nixosModules/minecraft-server.nix
           impermanenceStub
         ];
-        thoughtfull.services.minecraft-server.enable = true;
+        services.minecraft-server.enable = true;
 
         # Swap the real PaperMC jar for a harmless fake so the test doesn't
         # need internet access to let Paperclip download the vanilla server

--- a/tests/minecraft-server.nix
+++ b/tests/minecraft-server.nix
@@ -1,0 +1,115 @@
+{ nixpkgs, ... }:
+let
+  # Stub thoughtfull.impermanence.directories so this test doesn't need to
+  # pull in the full impermanence module (disko, etc.) just to check that
+  # minecraft-server.nix appends to it.
+  impermanenceStub =
+    { lib, ... }:
+    {
+      options.thoughtfull.impermanence.directories = lib.mkOption {
+        type = lib.types.listOf lib.types.anything;
+        default = [ ];
+      };
+    };
+in
+nixpkgs.testers.nixosTest {
+  name = "minecraft-server";
+
+  skipTypeCheck = true;
+  skipLint = true;
+
+  nodes = {
+    enabled =
+      {
+        config,
+        pkgs,
+        ...
+      }:
+      {
+        imports = [
+          ../nixosModules/minecraft-server.nix
+          impermanenceStub
+        ];
+        thoughtfull.services.minecraft-server.enable = true;
+
+        # Swap the real PaperMC jar for a harmless fake so the test doesn't
+        # need internet access to let Paperclip download the vanilla server
+        # jar it wraps.
+        services.minecraft-server.package = pkgs.writeShellScriptBin "minecraft-server" ''
+          echo "fake minecraft server started"
+          exec cat
+        '';
+
+        assertions = [
+          {
+            assertion = config.services.minecraft-server.eula;
+            message = "eula should default to true";
+          }
+          {
+            assertion = config.services.minecraft-server.declarative;
+            message = "declarative should default to true so serverProperties take effect";
+          }
+          {
+            assertion = config.services.minecraft-server.openFirewall;
+            message = "openFirewall should default to true";
+          }
+          {
+            assertion = builtins.elem 25565 config.networking.firewall.allowedTCPPorts;
+            message = "the default server port should be opened in the firewall";
+          }
+          {
+            assertion = builtins.any (
+              d: (d.directory or null) == config.services.minecraft-server.dataDir
+            ) config.thoughtfull.impermanence.directories;
+            message = "expected minecraft-server dataDir persistence directory";
+          }
+        ];
+      };
+
+    disabled =
+      { config, ... }:
+      {
+        imports = [
+          ../nixosModules/minecraft-server.nix
+          impermanenceStub
+        ];
+
+        assertions = [
+          {
+            assertion = !config.services.minecraft-server.enable;
+            message = "minecraft-server should stay disabled by default";
+          }
+          {
+            assertion = config.thoughtfull.impermanence.directories == [ ];
+            message = "no persistence directory should be added when disabled";
+          }
+        ];
+      };
+  };
+
+  testScript = ''
+    start_all()
+    enabled.wait_for_unit("multi-user.target")
+    disabled.wait_for_unit("multi-user.target")
+
+    with subtest("enabled: minecraft-server.service reaches active"):
+        enabled.wait_for_unit("minecraft-server.service")
+        enabled.succeed("systemctl is-active --quiet minecraft-server.service")
+
+    with subtest("enabled: eula is accepted on disk"):
+        eula = enabled.succeed("cat /var/lib/minecraft/eula.txt")
+        print(f"eula.txt:\n{eula}")
+        assert "eula=true" in eula
+
+    with subtest("enabled: default server properties are rendered declaratively"):
+        properties = enabled.succeed("cat /var/lib/minecraft/server.properties")
+        print(f"server.properties:\n{properties}")
+        assert "difficulty=2" in properties
+        assert "gamemode=0" in properties
+        assert "max-players=5" in properties
+        assert "server-port=25565" in properties
+
+    with subtest("disabled: minecraft-server.service is not present"):
+        disabled.fail("systemctl status minecraft-server.service")
+  '';
+}


### PR DESCRIPTION
## Summary
- New `nixosModules/minecraft-server.nix` (`thoughtfull.services.minecraft-server`) wraps `services.minecraft-server` with EULA acceptance, firewall, and impermanence persistence for `/var/lib/minecraft`.
- Enabled on tislit.
- Pins a custom `pkgs.thoughtfull.papermc-26-2` package (`packages/papermc-26-2.nix`) fetching Paper 26.2 directly from PaperMC's new build API and wrapping it with `jdk25`, since nixpkgs' `papermc` is stuck on 1.21.11 — its update script still targets PaperMC's sunset v2 API and can't see builds under the new date-based versioning ([nixpkgs#527546](https://github.com/NixOS/nixpkgs/issues/527546)). Delete this package and switch back to `pkgs.papermc` once that lands upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)