### PR TITLE
Don't alert when restic-stop-before-sleep interrupts a backup

### DIFF
--- a/nixosModules/restic.nix
+++ b/nixosModules/restic.nix
@@ -12,7 +12,12 @@ let
     passwordFile
     repositoryFile
     ;
-  inherit (lib) mkEnableOption mkIf mkOption;
+  inherit (lib)
+    mkDefault
+    mkEnableOption
+    mkIf
+    mkOption
+    ;
   inherit (lib.types) nullOr path;
 in
 {
@@ -49,6 +54,7 @@ in
         Persistent = true;
       };
     };
+    systemd.services.restic-backups-default.serviceConfig.SuccessExitStatus = mkDefault [ 130 ];
     systemd.services.restic-stop-before-sleep = {
       description = "Stop restic backup before sleep to avoid an orphaned repo lock breaking backups on other hosts";
       before = [ "sleep.target" ];

--- a/nixosModules/restic.nix
+++ b/nixosModules/restic.nix
@@ -54,6 +54,8 @@ in
         Persistent = true;
       };
     };
+    # restic exits 130 when terminated by SIGINT/SIGTERM (e.g. by
+    # restic-stop-before-sleep below); don't treat that as a failure.
     systemd.services.restic-backups-default.serviceConfig.SuccessExitStatus = mkDefault [ 130 ];
     systemd.services.restic-stop-before-sleep = {
       description = "Stop restic backup before sleep to avoid an orphaned repo lock breaking backups on other hosts";

--- a/tests/restic.nix
+++ b/tests/restic.nix
@@ -74,5 +74,17 @@ nixpkgs.testers.nixosTest {
         assert "restic-backups-default.service" in exec_start, (
             "expected ExecStart to stop restic-backups-default.service"
         )
+
+    with subtest(
+        "restic-backups-default treats exit code 130 (restic's graceful response to being stopped) as success"
+    ):
+        success_exit_status = machine.succeed(
+            "systemctl show restic-backups-default.service --property=SuccessExitStatus --value"
+        )
+        print(f"SuccessExitStatus={success_exit_status}")
+        assert "130" in success_exit_status.split(), (
+            "expected SuccessExitStatus to include 130 so restic-stop-before-sleep "
+            "stopping the backup mid-run isn't reported as a failure"
+        )
   '';
 }


### PR DESCRIPTION
## Summary
- `restic-backups-default.service` exits with code 130 when `restic-stop-before-sleep` stops it before suspend (restic's graceful response to SIGTERM), but systemd was marking that as a failed unit and firing the `OnFailure` ntfy alert on every laptop sleep mid-backup.
- Sets `serviceConfig.SuccessExitStatus = mkDefault [ 130 ]` on `restic-backups-default.service` so this graceful stop is no longer treated as a failure.
- Adds a test asserting `SuccessExitStatus` includes 130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)