### PR TITLE
Multiplex github SSH connections to save YubiKey touches

### DIFF
--- a/nixosConfigurations/aegle.nix
+++ b/nixosConfigurations/aegle.nix
@@ -27,7 +27,15 @@
           variables.PSQL_PAGER = "${pkgs.less}/bin/less -S --header 2";
         };
         networking.hostName = "aegle";
-        programs.git.lfs.enable = true;
+        programs.git = {
+          # Let git-lfs defer SSH connection multiplexing to ssh_config instead
+          # of opening its own private control socket. Combined with the
+          # ControlMaster config for github.com (see git.nix), this lets
+          # git-lfs-transfer reuse the master connection git already opened for
+          # the push, so an LFS-backed push needs a single YubiKey touch.
+          config.lfs.ssh.automultiplex = false;
+          lfs.enable = true;
+        };
         services = {
           clamav = {
             daemon.enable = true;

--- a/nixosModules/git.nix
+++ b/nixosModules/git.nix
@@ -29,6 +29,22 @@ in
       init.defaultBranch = mkDefault "main";
       pull.rebase = mkDefault false;
     };
+    # Reuse a single authenticated connection for github.com. A push can open
+    # several separate SSH connections (git-receive-pack, and for LFS-backed
+    # repos git-lfs-transfer and git-upload-pack), and with a touch-required
+    # FIDO2 key each connection would otherwise demand its own YubiKey touch.
+    # Multiplexing collapses them onto one master so they share a single touch.
+    # The master lives for the whole push regardless of duration (it always has
+    # an active client); ControlPersist only sets how long it lingers idle
+    # afterward. 10m mirrors gpg-agent's default-cache-ttl so quick follow-up
+    # pushes/pulls reuse it without another touch. The socket lives under
+    # /run/user so it is tmpfs-backed and never lands in the persistent store.
+    programs.ssh.extraConfig = ''
+      Host github.com
+        ControlMaster auto
+        ControlPath /run/user/%i/ssh-control-%C
+        ControlPersist 10m
+    '';
     thoughtfull.impermanence.user.directories = mkIf git.enable [ ".config/git" ];
   };
 }

--- a/tests.nix
+++ b/tests.nix
@@ -20,6 +20,7 @@ forEachSystem (
     avahi = callTest ./tests/avahi.nix;
     default = callTest ./tests/default.nix;
     dev = callTest ./tests/dev.nix;
+    git = callTest ./tests/git.nix;
     github-token = callTest ./tests/github-token.nix;
     graphical = callTest ./tests/graphical.nix;
     kanshi = callTest ./tests/kanshi.nix;

--- a/tests/git.nix
+++ b/tests/git.nix
@@ -1,0 +1,52 @@
+{ nixpkgs, ... }:
+let
+  stubs = import ./stubs.nix;
+in
+nixpkgs.testers.nixosTest {
+  name = "git";
+
+  skipTypeCheck = true;
+  skipLint = true;
+
+  nodes = {
+    machine =
+      { ... }:
+      {
+        imports = [
+          ../nixosModules/git.nix
+          stubs.impermanence
+        ];
+        programs.git = {
+          enable = true;
+          config = {
+            user.name = "test";
+            user.email = "test@example.com";
+            # Mirror the aegle host config so the git-lfs multiplexing opt-out is
+            # exercised end to end.
+            lfs.ssh.automultiplex = false;
+          };
+          lfs.enable = true;
+        };
+      };
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("ssh_config multiplexes github.com connections"):
+        ssh_config = machine.succeed("cat /etc/ssh/ssh_config")
+        print(f"/etc/ssh/ssh_config:\n{ssh_config}")
+        assert "Host github.com" in ssh_config, "expected a github.com ssh host block"
+        assert "ControlMaster auto" in ssh_config, "expected ControlMaster auto"
+        assert "ControlPath /run/user/%i/ssh-control-%C" in ssh_config, (
+            "expected tmpfs-backed ControlPath"
+        )
+        assert "ControlPersist 10m" in ssh_config, "expected ControlPersist 10m"
+
+    with subtest("gitconfig opts git-lfs out of its own ssh multiplexing"):
+        gitconfig = machine.succeed("cat /etc/gitconfig")
+        print(f"/etc/gitconfig:\n{gitconfig}")
+        assert "automultiplex = false" in gitconfig, "expected lfs.ssh.automultiplex = false"
+  '';
+}


### PR DESCRIPTION
A push to an LFS-backed repo opened several separate SSH connections (git-receive-pack, and for LFS also git-lfs-transfer and git-upload-pack). With a touch-required FIDO2 key and no connection reuse, each connection demanded its own YubiKey touch, so a push cost three or more touches while a pull cost one.

Multiplex github.com connections onto a single master via ssh_config so they share one touch. On aegle, where git-lfs is enabled, also set lfs.ssh.automultiplex = false so git-lfs stops forcing its own private control socket and reuses that master too.

ControlPersist is 10m to mirror gpg-agent's default-cache-ttl, and the control socket lives under /run/user so it stays off the persistent store.