### PR TITLE
Add technosophist.github.com ssh alias offering both authorized keys

### DIFF
--- a/nixosModules/git.nix
+++ b/nixosModules/git.nix
@@ -3,10 +3,15 @@ let
   inherit (builtins) any;
   inherit (config.programs) git;
   inherit (lib)
+    concatMapStringsSep
     mkDefault
     mkIf
+    mkOption
+    types
     ;
+  cfg = config.thoughtfull.programs.git;
   hasSigningkey = any (c: c ? user.signingkey && c.user.signingkey != null) git.config;
+  identityFileLines = concatMapStringsSep "\n" (f: "  IdentityFile ${f}") cfg.identityFiles;
 in
 {
   config = {
@@ -44,7 +49,26 @@ in
         ControlMaster auto
         ControlPath /run/user/%i/ssh-control-%C
         ControlPersist 10m
+
+      # technosophist.github.com is a synthetic alias that forwards straight
+      # through to github.com, offering both authorized keys as identities.
+      # %n (the alias as matched, before the HostName rewrite above resolves
+      # it to github.com) keeps this ControlPath distinct from the github.com
+      # block's, so the two never share a multiplexed connection.
+      Host technosophist.github.com
+        HostName github.com
+      ${identityFileLines}
+        ControlMaster auto
+        ControlPath /run/user/%i/ssh-control-%n-%C
+        ControlPersist 10m
     '';
     thoughtfull.impermanence.user.directories = mkIf git.enable [ ".config/git" ];
+  };
+  options.thoughtfull.programs.git.identityFiles = mkOption {
+    default = [
+      "~/.ssh/id_ed25519_sk_ypa766_auth"
+      "~/.ssh/id_ed25519_sk_ypc940_auth"
+    ];
+    type = types.listOf types.str;
   };
 }

--- a/nixosModules/git.nix
+++ b/nixosModules/git.nix
@@ -47,6 +47,9 @@ in
     #
     # technosophist.github.com is a synthetic alias that forwards straight
     # through to github.com, offering both authorized keys as identities.
+    # These are the same two keys on every machine (identityFiles points at
+    # public key files committed to the repo, unlike the per-machine
+    # openssh.authorizedKeys.keys pulled from GitHub via thoughtfull.user).
     # IdentitiesOnly restricts it to exactly these two, regardless of what
     # else is loaded in the agent, so the identity used here is predictable.
     # %n (the alias as matched, before the HostName rewrite below resolves it
@@ -70,9 +73,9 @@ in
   };
   options.thoughtfull.programs.git.identityFiles = mkOption {
     default = [
-      "~/.ssh/id_ed25519_sk_ypa766_auth"
-      "~/.ssh/id_ed25519_sk_ypc940_auth"
+      ./git/id_ed25519_sk_ypa766_auth.pub
+      ./git/id_ed25519_sk_ypc940_auth.pub
     ];
-    type = types.listOf types.str;
+    type = types.listOf types.path;
   };
 }

--- a/nixosModules/git.nix
+++ b/nixosModules/git.nix
@@ -44,20 +44,24 @@ in
     # afterward. 10m mirrors gpg-agent's default-cache-ttl so quick follow-up
     # pushes/pulls reuse it without another touch. The socket lives under
     # /run/user so it is tmpfs-backed and never lands in the persistent store.
+    #
+    # technosophist.github.com is a synthetic alias that forwards straight
+    # through to github.com, offering both authorized keys as identities.
+    # IdentitiesOnly restricts it to exactly these two, regardless of what
+    # else is loaded in the agent, so the identity used here is predictable.
+    # %n (the alias as matched, before the HostName rewrite below resolves it
+    # to github.com) keeps this ControlPath distinct from the github.com
+    # block's, so the two never share a multiplexed connection.
     programs.ssh.extraConfig = ''
       Host github.com
         ControlMaster auto
         ControlPath /run/user/%i/ssh-control-%C
         ControlPersist 10m
 
-      # technosophist.github.com is a synthetic alias that forwards straight
-      # through to github.com, offering both authorized keys as identities.
-      # %n (the alias as matched, before the HostName rewrite above resolves
-      # it to github.com) keeps this ControlPath distinct from the github.com
-      # block's, so the two never share a multiplexed connection.
       Host technosophist.github.com
         HostName github.com
       ${identityFileLines}
+        IdentitiesOnly yes
         ControlMaster auto
         ControlPath /run/user/%i/ssh-control-%n-%C
         ControlPersist 10m

--- a/nixosModules/git.nix
+++ b/nixosModules/git.nix
@@ -6,12 +6,15 @@ let
     concatMapStringsSep
     mkDefault
     mkIf
-    mkOption
-    types
     ;
-  cfg = config.thoughtfull.programs.git;
   hasSigningkey = any (c: c ? user.signingkey && c.user.signingkey != null) git.config;
-  identityFileLines = concatMapStringsSep "\n" (f: "  IdentityFile ${f}") cfg.identityFiles;
+  # The same two keys on every machine, unlike the per-machine
+  # openssh.authorizedKeys.keys pulled from GitHub via thoughtfull.user.
+  identityFiles = [
+    ./git/id_ed25519_sk_ypa766_auth.pub
+    ./git/id_ed25519_sk_ypc940_auth.pub
+  ];
+  identityFileLines = concatMapStringsSep "\n" (f: "  IdentityFile ${f}") identityFiles;
 in
 {
   config = {
@@ -47,9 +50,6 @@ in
     #
     # technosophist.github.com is a synthetic alias that forwards straight
     # through to github.com, offering both authorized keys as identities.
-    # These are the same two keys on every machine (identityFiles points at
-    # public key files committed to the repo, unlike the per-machine
-    # openssh.authorizedKeys.keys pulled from GitHub via thoughtfull.user).
     # IdentitiesOnly restricts it to exactly these two, regardless of what
     # else is loaded in the agent, so the identity used here is predictable.
     # %n (the alias as matched, before the HostName rewrite below resolves it
@@ -70,12 +70,5 @@ in
         ControlPersist 10m
     '';
     thoughtfull.impermanence.user.directories = mkIf git.enable [ ".config/git" ];
-  };
-  options.thoughtfull.programs.git.identityFiles = mkOption {
-    default = [
-      ./git/id_ed25519_sk_ypa766_auth.pub
-      ./git/id_ed25519_sk_ypc940_auth.pub
-    ];
-    type = types.listOf types.path;
   };
 }

--- a/nixosModules/git/id_ed25519_sk_ypa766_auth.pub
+++ b/nixosModules/git/id_ed25519_sk_ypa766_auth.pub
@@ -1,0 +1,1 @@
+sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIBH8BPuLHEG9nUM0dT5OpVVOFYXkAzNtqBEe8gmiqiyaAAAAGHNzaDp0ZWNobm9zb3BoaXN0QHlwYTc2Ng== ssh:technosophist@ypa766

--- a/nixosModules/git/id_ed25519_sk_ypc940_auth.pub
+++ b/nixosModules/git/id_ed25519_sk_ypc940_auth.pub
@@ -1,0 +1,1 @@
+sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIEDgkhMHrfTSQU8pBZgvrupKyChQ8rRTD7eOQ1j7G78/AAAAGHNzaDp0ZWNobm9zb3BoaXN0QHlwYzk0MA== ssh:technosophist@ypc940

--- a/tests/git.nix
+++ b/tests/git.nix
@@ -44,6 +44,27 @@ nixpkgs.testers.nixosTest {
         )
         assert "ControlPersist 10m" in ssh_config, "expected ControlPersist 10m"
 
+    with subtest("ssh_config aliases technosophist.github.com through to github.com"):
+        ssh_config = machine.succeed("cat /etc/ssh/ssh_config")
+        assert "Host technosophist.github.com" in ssh_config, (
+            "expected a technosophist.github.com ssh host block"
+        )
+        assert "HostName github.com" in ssh_config, (
+            "expected technosophist.github.com to forward through to github.com"
+        )
+        assert "IdentityFile ~/.ssh/id_ed25519_sk_ypa766_auth" in ssh_config, (
+            "expected first authorized ssh key as an identity"
+        )
+        assert "IdentityFile ~/.ssh/id_ed25519_sk_ypc940_auth" in ssh_config, (
+            "expected second authorized ssh key as an identity"
+        )
+        assert "ControlPath /run/user/%i/ssh-control-%n-%C" in ssh_config, (
+            "expected technosophist.github.com to have its own ControlMaster socket"
+        )
+        assert ssh_config.count("ControlPersist 10m") == 2, (
+            "expected both github.com and technosophist.github.com to persist for 10m"
+        )
+
     with subtest("gitconfig opts git-lfs out of its own ssh multiplexing"):
         gitconfig = machine.succeed("cat /etc/gitconfig")
         print(f"/etc/gitconfig:\n{gitconfig}")

--- a/tests/git.nix
+++ b/tests/git.nix
@@ -58,6 +58,9 @@ nixpkgs.testers.nixosTest {
         assert "IdentityFile ~/.ssh/id_ed25519_sk_ypc940_auth" in ssh_config, (
             "expected second authorized ssh key as an identity"
         )
+        assert "IdentitiesOnly yes" in ssh_config, (
+            "expected technosophist.github.com to restrict to only its configured keys"
+        )
         assert "ControlPath /run/user/%i/ssh-control-%n-%C" in ssh_config, (
             "expected technosophist.github.com to have its own ControlMaster socket"
         )

--- a/tests/git.nix
+++ b/tests/git.nix
@@ -52,11 +52,14 @@ nixpkgs.testers.nixosTest {
         assert "HostName github.com" in ssh_config, (
             "expected technosophist.github.com to forward through to github.com"
         )
-        assert "IdentityFile ~/.ssh/id_ed25519_sk_ypa766_auth" in ssh_config, (
-            "expected first authorized ssh key as an identity"
+        assert "IdentityFile /nix/store/" in ssh_config, (
+            "expected identities to point at nix store paths, not per-machine home paths"
         )
-        assert "IdentityFile ~/.ssh/id_ed25519_sk_ypc940_auth" in ssh_config, (
-            "expected second authorized ssh key as an identity"
+        assert "id_ed25519_sk_ypa766_auth.pub" in ssh_config, (
+            "expected first authorized ssh public key as an identity"
+        )
+        assert "id_ed25519_sk_ypc940_auth.pub" in ssh_config, (
+            "expected second authorized ssh public key as an identity"
         )
         assert "IdentitiesOnly yes" in ssh_config, (
             "expected technosophist.github.com to restrict to only its configured keys"


### PR DESCRIPTION
## Summary
- Adds a `Host technosophist.github.com` block to `nixosModules/git.nix` that forwards straight through to `github.com` (`HostName github.com`) while restricting to two hard-coded authorized identity keys via `IdentitiesOnly yes`.
- The two identities are public key files committed at `nixosModules/git/id_ed25519_sk_ypa766_auth.pub` and `nixosModules/git/id_ed25519_sk_ypc940_auth.pub`, copied into the Nix store and referenced by `IdentityFile`. Using committed public keys (rather than `openssh.authorizedKeys.keys`, which is fetched per-machine from GitHub) keeps the identities consistent across every machine.
- Gives the alias its own `ControlMaster`/`ControlPersist 10m`, keyed by `%n` in `ControlPath` so it never shares a multiplexed socket with the existing `github.com` block.
- Extends `tests/git.nix` to assert the new host block, both public key identities, `IdentitiesOnly`, the distinct `ControlPath`, and 10m persistence on both blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)