### PR TITLE
Drop %C hash from technosophist.github.com ControlPath

### DIFF
--- a/nixosModules/git.nix
+++ b/nixosModules/git.nix
@@ -54,7 +54,9 @@ in
     # else is loaded in the agent, so the identity used here is predictable.
     # %n (the alias as matched, before the HostName rewrite below resolves it
     # to github.com) keeps this ControlPath distinct from the github.com
-    # block's, so the two never share a multiplexed connection.
+    # block's, so the two never share a multiplexed connection. %C is left
+    # out here: combined with the long alias it can overflow the Unix domain
+    # socket path length limit.
     programs.ssh.extraConfig = ''
       Host github.com
         ControlMaster auto
@@ -66,7 +68,7 @@ in
       ${identityFileLines}
         IdentitiesOnly yes
         ControlMaster auto
-        ControlPath /run/user/%i/ssh-control-%n-%C
+        ControlPath /run/user/%i/ssh-control-%n
         ControlPersist 10m
     '';
     thoughtfull.impermanence.user.directories = mkIf git.enable [ ".config/git" ];

--- a/tests/git.nix
+++ b/tests/git.nix
@@ -64,7 +64,7 @@ nixpkgs.testers.nixosTest {
         assert "IdentitiesOnly yes" in ssh_config, (
             "expected technosophist.github.com to restrict to only its configured keys"
         )
-        assert "ControlPath /run/user/%i/ssh-control-%n-%C" in ssh_config, (
+        assert "ControlPath /run/user/%i/ssh-control-%n" in ssh_config, (
             "expected technosophist.github.com to have its own ControlMaster socket"
         )
         assert ssh_config.count("ControlPersist 10m") == 2, (


### PR DESCRIPTION
## Summary
- The technosophist.github.com ControlPath combined `%n-%C`, and the long alias plus the hash overflowed the Unix domain socket path length limit
- Drop `%C`, keeping just `%n` — still distinct from the github.com block's `%C`-only path, so the two never share a multiplexed master