### PR TITLE
Restrict github.com ssh alias to keys pulled from GitHub

### DIFF
--- a/nixosModules/git.nix
+++ b/nixosModules/git.nix
@@ -1,12 +1,21 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   inherit (builtins) any;
   inherit (config.programs) git;
+  inherit (config.thoughtfull.user) github;
   inherit (lib)
     concatMapStringsSep
+    filter
+    imap0
     mkDefault
     mkIf
     ;
+  inherit (lib.thoughtfull) githubKeys;
   hasSigningkey = any (c: c ? user.signingkey && c.user.signingkey != null) git.config;
   # The same two keys on every machine, unlike the per-machine
   # openssh.authorizedKeys.keys pulled from GitHub via thoughtfull.user.
@@ -15,6 +24,16 @@ let
     ./git/id_ed25519_sk_ypc940_auth.pub
   ];
   identityFileLines = concatMapStringsSep "\n" (f: "  IdentityFile ${f}") identityFiles;
+  # github.com itself is restricted to the keys pulled from GitHub for this
+  # machine's user (the same keys used for openssh.authorizedKeys), one file
+  # per key so each can be offered as its own IdentityFile.
+  githubIdentityFiles = imap0 (i: key: pkgs.writeText "github-com-identity-${toString i}.pub" key) (
+    filter (key: key != "") (githubKeys {
+      sha256 = github.keysHash;
+      username = github.user;
+    })
+  );
+  githubIdentityFileLines = concatMapStringsSep "\n" (f: "  IdentityFile ${f}") githubIdentityFiles;
 in
 {
   config = {
@@ -26,6 +45,12 @@ in
       {
         assertion = !git.enable || any (c: c ? user.name && c.user.name != null) git.config;
         message = "programs.git.config.user.name is not configured";
+      }
+      {
+        # An empty list here would silently combine with the unconditional
+        # IdentitiesOnly yes below to lock github.com out of SSH auth entirely.
+        assertion = githubIdentityFiles != [ ];
+        message = "thoughtfull.user.github (user = \"${github.user}\") pulled no keys from GitHub";
       }
     ];
     programs.git.config = {
@@ -48,6 +73,11 @@ in
     # pushes/pulls reuse it without another touch. The socket lives under
     # /run/user so it is tmpfs-backed and never lands in the persistent store.
     #
+    # github.com is restricted to the keys pulled from GitHub for this
+    # machine's user, so pushes/clones against the real hostname offer only
+    # identities GitHub itself already vouches for, regardless of what else is
+    # loaded in the agent.
+    #
     # technosophist.github.com is a synthetic alias that forwards straight
     # through to github.com, offering both authorized keys as identities.
     # IdentitiesOnly restricts it to exactly these two, regardless of what
@@ -59,6 +89,8 @@ in
     # socket path length limit.
     programs.ssh.extraConfig = ''
       Host github.com
+      ${githubIdentityFileLines}
+        IdentitiesOnly yes
         ControlMaster auto
         ControlPath /run/user/%i/ssh-control-%C
         ControlPersist 10m

--- a/tests/git.nix
+++ b/tests/git.nix
@@ -1,8 +1,17 @@
-{ nixpkgs, ... }:
+{ nixpkgs, self, ... }:
 let
   stubs = import ./stubs.nix;
+
+  # Importing nixosModules/git.nix requires lib.thoughtfull.githubKeys, and
+  # module-set nixpkgs.overlays are ignored with external pkgs, so provide both
+  # through the pkgs instance used by nixosTest.
+  testPkgs = (nixpkgs.extend self.overlays.thoughtfull).extend (
+    _: prev: {
+      lib = prev.lib.extend (_: _: { thoughtfull = self.lib.thoughtfull; });
+    }
+  );
 in
-nixpkgs.testers.nixosTest {
+testPkgs.testers.nixosTest {
   name = "git";
 
   skipTypeCheck = true;
@@ -15,6 +24,7 @@ nixpkgs.testers.nixosTest {
         imports = [
           ../nixosModules/git.nix
           stubs.impermanence
+          stubs.userGithub
         ];
         programs.git = {
           enable = true;
@@ -43,6 +53,17 @@ nixpkgs.testers.nixosTest {
             "expected tmpfs-backed ControlPath"
         )
         assert "ControlPersist 10m" in ssh_config, "expected ControlPersist 10m"
+
+    with subtest("ssh_config restricts github.com to the keys pulled from GitHub"):
+        ssh_config = machine.succeed("cat /etc/ssh/ssh_config")
+        github_block = ssh_config.split("Host technosophist.github.com")[0]
+        assert "IdentityFile /nix/store/" in github_block, (
+            "expected github.com identities to point at nix store paths built from "
+            "the keys pulled from GitHub"
+        )
+        assert "IdentitiesOnly yes" in github_block, (
+            "expected github.com to restrict to only the keys pulled from GitHub"
+        )
 
     with subtest("ssh_config aliases technosophist.github.com through to github.com"):
         ssh_config = machine.succeed("cat /etc/ssh/ssh_config")

--- a/tests/stubs.nix
+++ b/tests/stubs.nix
@@ -47,6 +47,26 @@
       };
     };
 
+  # Stub thoughtfull.user.github.{user,keysHash} for tests that need the
+  # per-machine keys pulled from GitHub without importing the full user.nix
+  # module (accounts-daemon, icons, hashed passwords, etc.). Mirrors the real
+  # defaults from nixosModules/user.nix so the fixed-output fetch resolves to
+  # an already-known-good hash.
+  userGithub =
+    { lib, ... }:
+    {
+      options.thoughtfull.user.github = {
+        user = lib.mkOption {
+          type = lib.types.str;
+          default = "technosophist";
+        };
+        keysHash = lib.mkOption {
+          type = lib.types.str;
+          default = "1dzq0125fmng19v088xv7pqq9c42wli75m44cglvxr2xayyz46mr";
+        };
+      };
+    };
+
   # Stub thoughtfull.impermanence.{directories,user.{files,directories}} for
   # tests that check persistence lists without importing the full impermanence
   # module.


### PR DESCRIPTION
## Summary
- The `Host github.com` ssh block had no identity restriction, so any key loaded in the agent could be offered for pushes/clones against the real hostname
- Add `IdentityFile`/`IdentitiesOnly yes` sourced from the per-machine `thoughtfull.user.github` keys (the same ones used for `openssh.authorizedKeys`), mirroring the existing restriction already in place on the `technosophist.github.com` alias
- Add an assertion guarding against an empty key list silently combining with `IdentitiesOnly yes` to lock `github.com` out of SSH auth entirely (the exact footgun a same-day commit removed from the `technosophist.github.com` alias)

🤖 Generated with [Claude Code](https://claude.com/claude-code)