### PR TITLE
Let persisted directories/files opt out of restic backups

### DIFF
--- a/nixosModules/impermanence.nix
+++ b/nixosModules/impermanence.nix
@@ -7,13 +7,63 @@
 let
   inherit (config.thoughtfull) impermanence user;
   inherit (lib)
+    concatMap
+    concatStringsSep
+    filter
     mkDefault
     mkEnableOption
     mkIf
     mkOption
+    optional
+    splitString
     types
     unique
     ;
+
+  # environment.persistence's directory/file submodules are strict (no freeformType), so the
+  # backup/backupExclude fields added to dirOpts/fileOpts (impermanence/mounts.nix) must be
+  # stripped before merging into it.
+  stripDir =
+    d:
+    removeAttrs d [
+      "backup"
+      "backupExclude"
+    ];
+  stripFile = f: removeAttrs f [ "backup" ];
+
+  persistentPrefix = "/${impermanence.persistent.name}";
+  joinPath =
+    parts: "/" + concatStringsSep "/" (filter (s: s != "") (concatMap (p: splitString "/" p) parts));
+
+  directoryExcludes =
+    base: entries:
+    concatMap (
+      d:
+      (optional (!d.backup) (joinPath [
+        persistentPrefix
+        base
+        d.directory
+      ]))
+      ++ (map (
+        sub:
+        joinPath [
+          persistentPrefix
+          base
+          d.directory
+          sub
+        ]
+      ) (if d.backup then d.backupExclude else [ ]))
+    ) entries;
+  fileExcludes =
+    base: entries:
+    map (
+      f:
+      joinPath [
+        persistentPrefix
+        base
+        f.file
+      ]
+    ) (filter (f: !f.backup) entries);
 in
 {
   config = mkIf impermanence.enable {
@@ -33,18 +83,26 @@ in
           mode = "u=rwx,g=x,o=x";
         }
       ]
-      ++ (unique impermanence.directories);
+      ++ (map stripDir (unique impermanence.directories));
       files = [
         "/etc/machine-id"
       ]
-      ++ (unique impermanence.files);
+      ++ (map stripFile (unique impermanence.files));
       users.${user.name} = {
-        directories = unique impermanence.user.directories;
-        files = unique impermanence.user.files;
+        directories = map stripDir (unique impermanence.user.directories);
+        files = map stripFile (unique impermanence.user.files);
       };
     };
     fileSystems."/${impermanence.persistent.name}".neededForBoot = mkDefault true;
     services.btrfs.autoScrub.enable = mkDefault true;
+    services.restic.thoughtfull = {
+      paths = [ persistentPrefix ];
+      exclude =
+        (directoryExcludes "" (unique impermanence.directories))
+        ++ (directoryExcludes user.home (unique impermanence.user.directories))
+        ++ (fileExcludes "" (unique impermanence.files))
+        ++ (fileExcludes user.home (unique impermanence.user.files));
+    };
   };
   imports = [
     (import ./impermanence/mounts.nix {

--- a/nixosModules/impermanence/mounts.nix
+++ b/nixosModules/impermanence/mounts.nix
@@ -20,6 +20,25 @@ let
     group = "root";
   };
   dirOpts.options = {
+    backup = mkOption {
+      default = true;
+      description = ''
+        Whether this directory's contents should be included in restic backups. Set to false to
+        persist the directory across boots without backing it up (for example, a package manager
+        download cache).
+      '';
+      type = types.bool;
+    };
+    backupExclude = mkOption {
+      default = [ ];
+      description = ''
+        Paths relative to `directory` to exclude from restic backups, even though the directory
+        itself is backed up. Ignored if `backup` is false. Useful when a persisted directory has a
+        known cache subdirectory that shouldn't be backed up (for example, a game's asset cache).
+      '';
+      example = [ "cache" ];
+      type = types.listOf types.str;
+    };
     directory = mkOption {
       description = "The path to the directory.";
       type = types.str;
@@ -57,13 +76,29 @@ let
     };
   };
   fileOpts.options = {
+    backup = mkOption {
+      default = true;
+      description = ''
+        Whether this file should be included in restic backups. Set to false to persist the file
+        across boots without backing it up.
+      '';
+      type = types.bool;
+    };
     file = mkOption {
       description = "The path to the file.";
       type = types.str;
     };
-    parentDirectory = mapAttrs (
-      _: x: if x._type or null == "option" then x // { internal = true; } else x
-    ) dirOpts.options;
+    # backup/backupExclude describe restic handling for the directory/file itself; they have no
+    # meaningful effect on the parent directory created to hold it, so they're excluded here
+    # rather than mirrored in a way that looks configurable but silently does nothing.
+    parentDirectory =
+      mapAttrs (_: x: if x._type or null == "option" then x // { internal = true; } else x)
+        (
+          removeAttrs dirOpts.options [
+            "backup"
+            "backupExclude"
+          ]
+        );
   };
   rootFile = types.submodule [
     fileOpts

--- a/nixosModules/restic.nix
+++ b/nixosModules/restic.nix
@@ -18,7 +18,12 @@ let
     mkIf
     mkOption
     ;
-  inherit (lib.types) nullOr path;
+  inherit (lib.types)
+    listOf
+    nullOr
+    path
+    str
+    ;
 in
 {
   config = mkIf enable {
@@ -33,13 +38,14 @@ in
         "/persistent/home/**/.cache"
         "/persistent/home/**/Cache"
         "/persistent/home/**/cache"
-      ];
+      ]
+      ++ config.services.restic.thoughtfull.exclude;
       extraBackupArgs = [
         "--no-scan"
         "--retry-lock 1h"
       ];
       passwordFile = resticPassword.path;
-      paths = [ "/persistent" ];
+      paths = config.services.restic.thoughtfull.paths;
       pruneOpts = [
         "--retry-lock 1h"
         "--keep-hourly 24"
@@ -76,6 +82,22 @@ in
         EnvironmentFile as described by {manpage}systemd.exec(5)
       '';
       type = nullOr path;
+    };
+    exclude = mkOption {
+      default = [ ];
+      description = ''
+        Restic exclude patterns to append to the default backup's hardcoded cache-directory
+        excludes. Other modules (for example thoughtfull.impermanence) contribute to this list.
+      '';
+      type = listOf str;
+    };
+    paths = mkOption {
+      default = [ ];
+      description = ''
+        Paths for the default backup to back up. Other modules (for example
+        thoughtfull.impermanence) contribute to this list.
+      '';
+      type = listOf str;
     };
     passwordFile = mkOption {
       default = ../nixosConfigurations/shared/secrets/restic-password.age;

--- a/tests.nix
+++ b/tests.nix
@@ -23,6 +23,7 @@ forEachSystem (
     git = callTest ./tests/git.nix;
     github-token = callTest ./tests/github-token.nix;
     graphical = callTest ./tests/graphical.nix;
+    impermanence = callTest ./tests/impermanence.nix;
     kanshi = callTest ./tests/kanshi.nix;
     minecraft-server = callTest ./tests/minecraft-server.nix;
     monitoring = callTest ./tests/monitoring.nix;

--- a/tests/impermanence.nix
+++ b/tests/impermanence.nix
@@ -1,0 +1,127 @@
+# Lightweight nix eval check (not a nixosTest/VM boot) for the impermanence <-> restic
+# exclude-path wiring: verifying config.services.restic.thoughtfull.{paths,exclude} are
+# computed correctly from thoughtfull.impermanence.{directories,user.directories,user.files}
+# entries' `backup`/`backupExclude` fields, and that those two fields never leak into
+# environment.persistence.*.directories/files (whose upstream submodule is strict and
+# rejects unknown attributes).
+#
+# A full nixosTest VM boot was considered and rejected: building system.build.toplevel with
+# thoughtfull.impermanence.enable = true forces fileSystems."/persistent" (needs a real or
+# faked filesystem), thoughtfull.impermanence.disko.* (needs disko.devices declared), and the
+# rollback.nix initrd service (references a LUKS device path) -- none of which the two
+# behaviors under test depend on. Because Nix is lazy, evaluating only the specific
+# attributes below never forces any of that machinery.
+{ self, nixpkgs, ... }:
+let
+  inherit (nixpkgs) lib;
+  inherit (self.inputs.nixpkgs.lib) nixosSystem;
+
+  testUser = "testuser";
+  persistentPrefix = "/persistent";
+
+  defaultModule = import ../nixosModules/default.nix {
+    inputs = self.inputs // {
+      inherit self;
+    };
+  };
+
+  fixture = {
+    thoughtfull = {
+      user.name = testUser;
+      impermanence = {
+        directories = [
+          {
+            directory = "/var/lib/example-cache";
+            backup = false;
+          }
+          {
+            directory = "/var/lib/another-cache";
+            backupExclude = [ "tmp" ];
+          }
+        ];
+        user = {
+          directories = [
+            {
+              directory = ".minecraft";
+              backupExclude = [ "cache" ];
+            }
+          ];
+          files = [
+            {
+              file = ".m2/deps.jar";
+              backup = false;
+            }
+          ];
+        };
+      };
+    };
+  };
+
+  eval = nixosSystem {
+    system = nixpkgs.stdenv.hostPlatform.system;
+    lib = self.lib;
+    specialArgs = {
+      inputs = self.inputs // {
+        inherit self;
+      };
+    };
+    modules = [
+      defaultModule
+      fixture
+    ];
+  };
+
+  cfg = eval.config;
+
+  # environment.persistence's directory/file submodules are strict (no freeformType), so
+  # forcing each entry's attribute names only succeeds if backup/backupExclude were stripped
+  # before merging. builtins.length would only force the list spine, not each element, and so
+  # would never catch a leaked attribute -- attrNames forces the per-element submodule merge,
+  # where the "does not exist" rejection actually happens. tryEval turns that rejection into a
+  # clean check failure instead of an uncaught eval error.
+  noLeak = entries: builtins.all (d: (builtins.tryEval (builtins.attrNames d)).success) entries;
+
+  checks = [
+    {
+      name = "services.restic.thoughtfull.paths defaults to the persistent storage root";
+      ok = cfg.services.restic.thoughtfull.paths == [ persistentPrefix ];
+    }
+    {
+      name = "a system directory with backup = false is excluded";
+      ok = lib.elem "${persistentPrefix}/var/lib/example-cache" cfg.services.restic.thoughtfull.exclude;
+    }
+    {
+      name = "a system directory's backupExclude sub-path is excluded";
+      ok = lib.elem "${persistentPrefix}/var/lib/another-cache/tmp" cfg.services.restic.thoughtfull.exclude;
+    }
+    {
+      name = "a user directory's backupExclude sub-path is excluded";
+      ok = lib.elem "${persistentPrefix}/home/${testUser}/.minecraft/cache" cfg.services.restic.thoughtfull.exclude;
+    }
+    {
+      name = "a user file with backup = false is excluded";
+      ok = lib.elem "${persistentPrefix}/home/${testUser}/.m2/deps.jar" cfg.services.restic.thoughtfull.exclude;
+    }
+    {
+      name = "backup/backupExclude do not leak into environment.persistence (system directories)";
+      ok = noLeak cfg.environment.persistence."/persistent".directories;
+    }
+    {
+      name = "backup/backupExclude do not leak into environment.persistence (user directories)";
+      ok = noLeak cfg.environment.persistence."/persistent".users.${testUser}.directories;
+    }
+    {
+      name = "backup does not leak into environment.persistence (user files)";
+      ok = noLeak cfg.environment.persistence."/persistent".users.${testUser}.files;
+    }
+  ];
+
+  failed = builtins.filter (c: !c.ok) checks;
+in
+if failed != [ ] then
+  throw ''
+    impermanence/restic exclude test failed:
+    ${builtins.concatStringsSep "\n" (map (c: "  - ${c.name}") failed)}
+  ''
+else
+  nixpkgs.runCommand "impermanence-restic-exclude-test" { } "touch $out"


### PR DESCRIPTION
## Summary
- Add `backup`/`backupExclude` fields to the impermanence directory/file options so a persisted directory or file can skip restic backup entirely, or carve out a specific sub-path (e.g. persist `~/.minecraft` but skip `~/.minecraft/cache`)
- `impermanence.nix` strips those fields before merging into `environment.persistence` (whose upstream submodule is strict) and contributes computed absolute exclude paths to new `services.restic.thoughtfull.paths`/`.exclude` accumulator options
- `restic.nix` consumes those options for its default backup's `paths`/`exclude`, decoupled from any knowledge of impermanence's directory list
- New `tests/impermanence.nix`: a lightweight `nixosSystem` eval check (not a VM boot) verifying the computed paths/excludes and that `backup`/`backupExclude` don't leak into `environment.persistence`

🤖 Generated with [Claude Code](https://claude.com/claude-code)