### PR TITLE
Fix ssh-askpass to only skip dialog for pure touch notifications

### DIFF
--- a/packages/ssh-askpass.bash
+++ b/packages/ssh-askpass.bash
@@ -1,11 +1,12 @@
 #!@bash@
+set -euo pipefail
 
-prompt="${1:-}"
-
-# Only show dialog for PIN prompts
-if [[ $prompt =~ [Pp][Ii][Nn] ]]; then
-  @x11_ssh_askpass@ "$prompt"
-else
-  # Touch-only prompts - exit silently (user has other notifications)
-  exit 1
+# OpenSSH sets SSH_ASKPASS_PROMPT=none for notify_start() calls (touch/security-key
+# notifications where the response is discarded and the user has other notifications).
+# Every other case -- passphrase/PIN entry, host-key verification's yes/no confirm(),
+# and SSH_ASKPASS_PROMPT=confirm permission prompts -- needs a real answer.
+if [[ ${SSH_ASKPASS_PROMPT:-} == "none" ]]; then
+  exit 0
 fi
+
+exec @x11_ssh_askpass@ "$@"


### PR DESCRIPTION
## Summary
- The `ssh-askpass` wrapper regexed prompt text for "PIN" to decide whether to show the dialog, silently `exit 1`ing for anything else -- including host-key verification's yes/no `confirm()` and agent signing's "Allow use of key?" permission prompt, both of which were auto-declined without ever showing a dialog.
- Replace the regex with a check on `SSH_ASKPASS_PROMPT`, the hint OpenSSH itself sets (verified against OpenSSH 10.4p1 source, matching what nixpkgs 26.05 ships): only `none` (`notify_start()`'s fire-and-forget touch notifications, response discarded) is safe to skip; every other case needs a real answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)