### PR TITLE
Fix ssh-agent PIN prompts by using an absolute ssh-askpass path

### DIFF
--- a/nixosModules/openssh.nix
+++ b/nixosModules/openssh.nix
@@ -12,7 +12,20 @@ in
 {
   environment.systemPackages = mkIf graphical.enable [ ssh-askpass ];
   programs.ssh = {
-    askPassword = mkIf graphical.enable "ssh-askpass";
+    # An absolute path, not just "ssh-askpass": the ssh-agent systemd unit's
+    # own askpass wrapper execs this with the unit's minimal generated PATH
+    # (no /run/current-system/sw/bin), so a bare command name silently fails
+    # to resolve there. That failure is invisible for touch-only FIDO2 keys
+    # (their notify-only prompt never needs a real answer) but breaks PIN
+    # (verify-required) keys: ssh-agent gets no PIN back and the signature
+    # is refused with a misleading "incorrect passphrase" error.
+    #
+    # /run/current-system/sw/bin/ssh-askpass rather than "${ssh-askpass}/bin/
+    # ssh-askpass": the long-lived ssh-agent systemd unit resolves this path
+    # fresh on every invocation, so it keeps working across a nixos-rebuild
+    # switch without needing a restart. A baked-in store path would go stale
+    # (and eventually be garbage-collected) the moment ssh-askpass rebuilds.
+    askPassword = mkIf graphical.enable "/run/current-system/sw/bin/ssh-askpass";
     enableAskPassword = mkDefault graphical.enable;
     extraConfig = ''
       VerifyHostKeyDNS yes


### PR DESCRIPTION
## Summary
- `programs.ssh.askPassword` was the bare command `ssh-askpass`, resolved via `$PATH`. That works for interactive shells, but the `ssh-agent` systemd unit invokes askpass through its own wrapper using the unit's minimal generated PATH (no `/run/current-system/sw/bin`), so the exec silently failed.
- Touch-only FIDO2 keys never noticed, since their notify-only prompt discards the response either way. But `verify-required` (PIN) keys got no PIN back from the failed askpass invocation and were refused by the device, surfacing as a misleading `incorrect passphrase supplied to decrypt private key` / `agent refused operation` error.
- Point `askPassword` at the stable `/run/current-system/sw/bin/ssh-askpass` path instead of a bare command name or a baked-in store path — the long-lived `ssh-agent` unit resolves it fresh on every invocation, so it also survives a `nixos-rebuild switch` without needing the agent restarted.

Root-caused by restarting `ssh-agent` in debug/foreground mode and tracing the failure down through `ssh-agent.c`'s PIN-retry logic (`read_passphrase(..., RP_USE_ASKPASS)`) and the `askPasswordWrapper`'s `exec ssh-askpass` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)