### PR TITLE
Prefer yubikey touch over ssh-agent for sudo authentication

### DIFF
--- a/nixosModules/openssh.nix
+++ b/nixosModules/openssh.nix
@@ -6,7 +6,7 @@
 }:
 let
   inherit (config.thoughtfull) graphical;
-  inherit (lib) mkDefault mkIf;
+  inherit (lib) mkDefault mkIf mkOverride;
   inherit (pkgs.thoughtfull) ssh-askpass;
 in
 {
@@ -56,7 +56,14 @@ in
       # Both u2f and rssh are "sufficient", so auth stops at whichever succeeds first: prefer
       # touching the yubikey directly by running u2f before rssh. rssh then only kicks in as a
       # fallback when the yubikey isn't directly plugged in, e.g. over agent-forwarded ssh.
-      rules.auth.u2f.order = config.security.pam.services.sudo.rules.auth.rssh.order - 10;
+      #
+      # mkOverride 999 rather than mkDefault: the upstream default for this option is itself
+      # mkDefault (priority 1000), so a same-priority mkDefault here would conflict instead of
+      # overriding it. Priority 999 wins over that default while still leaving a plain value (or
+      # mkForce) in a host config free to override this in turn, same as rssh.order itself.
+      rules.auth.u2f.order = mkOverride 999 (
+        config.security.pam.services.sudo.rules.auth.rssh.order - 10
+      );
     };
   };
   services.openssh.hostKeys = [

--- a/nixosModules/openssh.nix
+++ b/nixosModules/openssh.nix
@@ -49,9 +49,15 @@ in
       # I have for sudo a separate key on my yubikey that requires touch.
       settings.auth_key_file = mkDefault "/etc/ssh/authorized_keys.d/\${ruser}_sudo";
     };
-    # I can ssh into a machine with agent forwarding and touch my yubikey locally to authenticate
-    # sudo.
-    services.sudo.rssh = mkDefault true;
+    services.sudo = {
+      # I can ssh into a machine with agent forwarding and touch my yubikey locally to authenticate
+      # sudo.
+      rssh = mkDefault true;
+      # Both u2f and rssh are "sufficient", so auth stops at whichever succeeds first: prefer
+      # touching the yubikey directly by running u2f before rssh. rssh then only kicks in as a
+      # fallback when the yubikey isn't directly plugged in, e.g. over agent-forwarded ssh.
+      rules.auth.u2f.order = config.security.pam.services.sudo.rules.auth.rssh.order - 10;
+    };
   };
   services.openssh.hostKeys = [
     {

--- a/tests.nix
+++ b/tests.nix
@@ -28,6 +28,7 @@ forEachSystem (
     minecraft-server = callTest ./tests/minecraft-server.nix;
     monitoring = callTest ./tests/monitoring.nix;
     nixfiles = callTest ./tests/nixfiles.nix;
+    openssh = callTest ./tests/openssh.nix;
     restic = callTest ./tests/restic.nix;
     system-pull = callTest ./tests/system-pull.nix;
     vpn = callTest ./tests/vpn.nix;

--- a/tests/openssh.nix
+++ b/tests/openssh.nix
@@ -1,0 +1,73 @@
+{ self, nixpkgs, ... }:
+let
+  # overlays applied here because module-set nixpkgs.overlays is ignored with external pkgs
+  extendedNixpkgs =
+    ((nixpkgs.extend self.overlays.thoughtfull).extend self.overlays.unstable).extend
+      (
+        _: prev: {
+          lib = prev.lib.extend (_: _: { thoughtfull = self.lib.thoughtfull; });
+        }
+      );
+  defaultModule = import ../nixosModules/default.nix {
+    inputs = self.inputs // {
+      inherit self;
+    };
+  };
+in
+extendedNixpkgs.testers.nixosTest {
+  name = "openssh";
+
+  skipTypeCheck = true;
+  skipLint = true;
+
+  nodes = {
+    machine =
+      { lib, ... }:
+      {
+        imports = [ defaultModule ];
+        # name must match the default keysHash so githubKeys hits the Nix store
+        thoughtfull.user.name = "technosophist";
+        # clear module-set nixpkgs.config to avoid the "external pkgs instance" assertion
+        nixpkgs.config = lib.mkForce { };
+        # openssh.nix disables automatic keygen; re-enable for the test VM
+        systemd.services.sshd-keygen.enable = lib.mkForce true;
+        # Disable services that need secrets or required options not suitable for a test VM
+        services.syncthing.enable = lib.mkForce false;
+        services.restic.thoughtfull.enable = lib.mkForce false;
+        thoughtfull = {
+          impermanence.enable = lib.mkForce false;
+          monitoring.enable = lib.mkForce false;
+        };
+      };
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("default: sudo tries the yubikey (u2f) before ssh-agent (rssh)"):
+        # Both pam_u2f and pam_rssh are "sufficient", so auth stops at whichever succeeds
+        # first. The yubikey should be tried before falling back to ssh-agent (which is
+        # what agent-forwarded ssh sessions rely on when no yubikey is plugged in).
+        pam_sudo = machine.succeed("cat /etc/pam.d/sudo")
+        print(f"/etc/pam.d/sudo:\n{pam_sudo}")
+
+        auth_lines = [
+            line
+            for line in pam_sudo.splitlines()
+            if "pam_u2f.so" in line or "libpam_rssh.so" in line
+        ]
+        assert len(auth_lines) == 2, f"expected one u2f line and one rssh line, got: {auth_lines}"
+
+        u2f_index = next(i for i, line in enumerate(auth_lines) if "pam_u2f.so" in line)
+        rssh_index = next(i for i, line in enumerate(auth_lines) if "libpam_rssh.so" in line)
+        assert u2f_index < rssh_index, "pam_u2f should come before pam_rssh in /etc/pam.d/sudo"
+
+    with subtest("default: rssh authenticates sudo against the dedicated sudo key file"):
+        pam_sudo = machine.succeed("cat /etc/pam.d/sudo")
+        rssh_line = next(line for line in pam_sudo.splitlines() if "libpam_rssh.so" in line)
+        assert "auth_key_file=/etc/ssh/authorized_keys.d/''${ruser}_sudo" in rssh_line, (
+            f"expected rssh to use the per-user sudo key file, got: {rssh_line}"
+        )
+  '';
+}


### PR DESCRIPTION
## Summary
- Reorder the sudo PAM auth stack so `pam_u2f` (physical yubikey touch) runs before `pam_rssh` (ssh-agent). Both are `sufficient`, so previously whichever was loaded in the agent won by default; now the yubikey is tried first, and ssh-agent (including agent forwarding from a remote host) is only used as a fallback when no yubikey is directly plugged in.
- Use `lib.mkOverride 999` for the new `rules.auth.u2f.order` value instead of a plain value, so it still wins over the upstream `mkDefault`-based default while remaining overridable from a host config the same way `rssh.order` already is.