### PR TITLE
Make waybar YubiKey notifier more resilient to crashes

### DIFF
--- a/nixosModules/sway/waybar/config.jsonc
+++ b/nixosModules/sway/waybar/config.jsonc
@@ -74,7 +74,8 @@
 
   "custom/yubikey": {
     "exec": "waybar-yubikey",
-    "return-type": "json"
+    "return-type": "json",
+    "restart-interval": 5
   },
 
   "custom/theme": {

--- a/packages/waybar-yubikey.bash
+++ b/packages/waybar-yubikey.bash
@@ -1,4 +1,5 @@
 #!@bash@
+set -euo pipefail
 
 socket="${XDG_RUNTIME_DIR:-/run/user/$UID}/yubikey-touch-detector.socket"
 

--- a/tests/waybar.nix
+++ b/tests/waybar.nix
@@ -329,6 +329,19 @@ testPkgs.testers.nixosTest {
         send("GPG_0")
         machine.wait_until_succeeds(f"tail -n1 {out} | grep -qv tooltip")
 
+    with subtest("waybar config restarts the yubikey widget if it exits"):
+        # custom/yubikey has no signal/interval, so waybar treats it as a
+        # continuous script and won't ever re-launch it if the process exits
+        # -- unlike the socket disappearing/reappearing, which the script's
+        # own outer retry loop already handles internally. restart-interval
+        # is the config-level safety net for the script crashing outright.
+        config = machine.succeed("cat /etc/xdg/waybar/config.jsonc")
+        block = config[config.index('"custom/yubikey": {') :]
+        block = block[: block.index("\n  },")]
+        assert '"restart-interval"' in block, (
+            "custom/yubikey should set restart-interval so waybar respawns it if it exits"
+        )
+
     with subtest("waybar config wires up the displays widget"):
         # The displays module is present and placed after the tray.
         config = machine.succeed("cat /etc/xdg/waybar/config.jsonc")


### PR DESCRIPTION
## Summary
- `custom/yubikey` in waybar's config has no `interval`/`signal`, so it's treated as a continuous script; if it ever exits outright (a crash, not just the detector socket going away and coming back, which the script's own reconnect loop already handles), waybar would never respawn it and the widget would go stale forever. Add `restart-interval: 5` as a safety net.
- Add `set -euo pipefail` to `waybar-yubikey.bash`, matching the convention already used by the other waybar widget scripts.
- Add a regression test asserting `custom/yubikey` sets `restart-interval`.