### PR TITLE
Add systemd user service to load SSH keys into ssh-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,17 @@ askpass every time, even when it just needs a touch.
 Hosts running the `ssh-agent-add-keys` systemd service (`nixosModules/openssh.nix`) load keys into
 the agent automatically on login instead of requiring `ssh-add -K` to be run by hand. That service
 doesn't talk to the YubiKey directly -- it globs for private key stub files already on disk, one
-directory per YubiKey (primary and backup) under `~/.ssh/<yubikey>/`. To provision those, run
+directory per YubiKey (primary and backup) under `~/.ssh/<yubikey>/`, matching any non-`.pub` file
+with `_auth_` or `_sign_` in its name. To provision those, run
 
 ```
 ssh-keygen -K
 ```
 
 with the YubiKey plugged in. This downloads the resident key stubs (and their `.pub` halves) to the
-current directory; copy them onto the target machine into `~/.ssh/<yubikey>/`, renaming as needed to
-match the `*_auth_<user>` / `*_sign_<user>` pattern already used for the committed `.pub` files under
-`nixosModules/user/<yubikey>/` (e.g. `id_ed25519_sk_rk_auth_technosophist`).
+current directory; copy them onto the target machine into `~/.ssh/<yubikey>/`, renaming as needed so
+the filename contains `_auth_` or `_sign_` (matching the naming already used for the committed `.pub`
+files under `nixosModules/user/<yubikey>/`, e.g. `id_ed25519_sk_rk_auth_technosophist`).
 
 My provision script requires me to touch every time I SSH, which gets to be annoying. I can either
 just deal with it because I don't provision often or I should go back to using a master connection,

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ ssh-add -K
 It requires entering the PIN to load the key, then only to touch after that. Annoyingly, it pops up
 askpass every time, even when it just needs a touch.
 
+Hosts running the `ssh-agent-add-keys` systemd service (`nixosModules/openssh.nix`) load keys into
+the agent automatically on login instead of requiring `ssh-add -K` to be run by hand. That service
+doesn't talk to the YubiKey directly -- it globs for private key stub files already on disk, one
+directory per YubiKey (primary and backup) under `~/.ssh/<yubikey>/`. To provision those, run
+
+```
+ssh-keygen -K
+```
+
+with the YubiKey plugged in. This downloads the resident key stubs (and their `.pub` halves) to the
+current directory; copy them onto the target machine into `~/.ssh/<yubikey>/`, renaming as needed to
+match the `*_auth_<user>` / `*_sign_<user>` pattern already used for the committed `.pub` files under
+`nixosModules/user/<yubikey>/` (e.g. `id_ed25519_sk_rk_auth_technosophist`).
+
 My provision script requires me to touch every time I SSH, which gets to be annoying. I can either
 just deal with it because I don't provision often or I should go back to using a master connection,
 I think that would help (though this may not help because even multiplexing it may still need a

--- a/nixosModules/openssh.nix
+++ b/nixosModules/openssh.nix
@@ -153,13 +153,21 @@ in
         pkgs.bash
         ssh.package
       ];
-      # Mirrors the ssh-agent unit itself (both the socket location and the
-      # askpass wiring): without SSH_AUTH_SOCK this would talk to no agent at
-      # all, and without DISPLAY/SSH_ASKPASS a PIN-protected (verify-required)
-      # FIDO2 key has no way to prompt from this non-interactive oneshot unit.
       environment = {
+        # Without this, this non-interactive oneshot unit would talk to no
+        # agent at all.
         SSH_AUTH_SOCK = "%t/ssh-agent";
-        DISPLAY = mkIf graphical.enable "fake";
+        # No DISPLAY here: the askpass helper (packages/ssh-askpass.bash) execs
+        # x11-ssh-askpass directly, which needs a real X11 display to open a
+        # window -- a placeholder value can't satisfy that (unlike the
+        # ssh-agent unit itself, whose own DISPLAY=fake only has to satisfy
+        # OpenSSH's `getenv("DISPLAY") != NULL` gate for its own agent-side
+        # confirm prompts, not actually open a display). Leaving DISPLAY unset
+        # here means this unit inherits whatever the systemd --user manager's
+        # environment already has -- nothing at the ssh-agent.service-triggered
+        # boot run, but the real DISPLAY once sway's nixos.conf imports it
+        # ahead of starting sway-session.target, same as every other
+        # sway-session.target unit (waybar, mako, kanshi) already relies on.
         SSH_ASKPASS = mkIf graphical.enable "/run/current-system/sw/bin/ssh-askpass";
       };
       serviceConfig = {

--- a/nixosModules/openssh.nix
+++ b/nixosModules/openssh.nix
@@ -12,9 +12,6 @@ let
   sshAgentAddKeysScript = writeFileScriptBin {
     name = "ssh-agent-add-keys";
     src = ./openssh/ssh-agent-add-keys.bash;
-    replacements = {
-      username = user.name;
-    };
   };
 in
 {

--- a/nixosModules/openssh.nix
+++ b/nixosModules/openssh.nix
@@ -23,6 +23,12 @@ in
     # manager and ssh-agent.service persist across logout, which they can
     # even without lingering enabled. Running the loader directly here, once
     # per login shell, covers that case.
+    #
+    # This reruns on *every* login shell -- not just the first one after
+    # boot, e.g. also each interactive `ssh` into this host. ssh-add itself
+    # doesn't check whether a key is already loaded before re-adding it (it
+    # would otherwise re-prompt for touch/PIN on a key already in the agent
+    # every time), so ssh-agent-add-keys.bash does that check itself.
     loginShellInit = mkIf ssh.startAgent (
       let
         # SSH_ASKPASS_REQUIRE=never: on graphical hosts, sway.nix's

--- a/nixosModules/openssh.nix
+++ b/nixosModules/openssh.nix
@@ -5,12 +5,59 @@
   ...
 }:
 let
-  inherit (config.thoughtfull) graphical;
+  inherit (config.programs) ssh;
+  inherit (config.thoughtfull) graphical user;
   inherit (lib) mkDefault mkIf mkOverride;
-  inherit (pkgs.thoughtfull) ssh-askpass;
+  inherit (pkgs.thoughtfull) ssh-askpass writeFileScriptBin;
+  sshAgentAddKeysScript = writeFileScriptBin {
+    name = "ssh-agent-add-keys";
+    src = ./openssh/ssh-agent-add-keys.bash;
+    replacements = {
+      username = user.name;
+    };
+  };
 in
 {
-  environment.systemPackages = mkIf graphical.enable [ ssh-askpass ];
+  environment = {
+    systemPackages = mkIf graphical.enable [ ssh-askpass ];
+    # The ssh-agent-add-keys unit (below) only reloads keys on ssh-agent
+    # start and, for graphical logins, on sway-session.target -- neither of
+    # which fires for a plain console re-login while the systemd --user
+    # manager and ssh-agent.service persist across logout, which they can
+    # even without lingering enabled. Running the loader directly here, once
+    # per login shell, covers that case.
+    loginShellInit = mkIf ssh.startAgent (
+      let
+        # SSH_ASKPASS_REQUIRE=never: on graphical hosts, sway.nix's
+        # sessionVariables.SSH_ASKPASS_REQUIRE = "prefer" applies PAM-wide,
+        # including plain console sessions -- left as-is, a console ssh-add
+        # would try to pop the GUI askpass helper with no display to render
+        # it on, and PIN-protected keys would silently fail to load. Forcing
+        # "never" here makes ssh-add prompt on this session's own terminal
+        # instead (touch-only keys don't need a prompt either way).
+        # `[ -t 0 ]` skips this for non-interactive login-shell invocations
+        # (e.g. `ssh host cmd`) that have no terminal to prompt on.
+        loadKeys = ''
+          if [ -t 0 ]; then
+            SSH_ASKPASS_REQUIRE=never ${sshAgentAddKeysScript}/bin/ssh-agent-add-keys || true
+          fi
+        '';
+      in
+      if graphical.enable then
+        ''
+          # tty1 is where sway autologins (see sway.nix): defer to the
+          # ssh-agent-add-keys unit's own sway-session.target trigger there,
+          # timed to run once Wayland/DISPLAY are actually available (needed
+          # for PIN-protected keys' GUI askpass) instead of blocking the tty1
+          # login on a touch/PIN prompt before exec'ing sway.
+          if [ "$(tty)" != "/dev/tty1" ]; then
+            ${loadKeys}
+          fi
+        ''
+      else
+        loadKeys
+    );
+  };
   programs.ssh = {
     # An absolute path, not just "ssh-askpass": the ssh-agent systemd unit's
     # own askpass wrapper execs this with the unit's minimal generated PATH
@@ -72,8 +119,59 @@ in
       type = "ed25519";
     }
   ];
-  # my boostrapping process uses a preconfigured key for hosts, so I don't need automatic keygen
-  systemd.services.sshd-keygen.enable = mkDefault false;
+  systemd = {
+    # my boostrapping process uses a preconfigured key for hosts, so I don't need automatic keygen
+    services.sshd-keygen.enable = mkDefault false;
+    user.services.ssh-agent-add-keys = mkIf ssh.startAgent {
+      description = "Load ${user.name}'s SSH auth/signing keys into ssh-agent";
+      # Two independent triggers to re-run this: ssh-agent.service (covers
+      # boot, and any agent restart) and sway-session.target (covers
+      # logout/login -- sway's nixos.conf explicitly starts/stops that target
+      # per session, so it cycles even when ssh-agent.service and the
+      # systemd --user manager itself persist across a logout). Without the
+      # second trigger, keys removed from the agent mid-session (e.g. the
+      # FIDO2 token was unplugged) never get reloaded just by logging back in.
+      #
+      # bindsTo only ssh-agent.service, not sway-session.target: BindsTo=
+      # implies a pull-up (like Requires=) in the direction *from* this unit,
+      # so binding to sway-session.target would drag the whole graphical
+      # session (waybar, mako, kanshi, ...) into whatever transaction starts
+      # this unit -- including the ssh-agent.service-triggered run at boot,
+      # well before sway itself is actually up on tty1. partOf only
+      # propagates stop/restart one-way, with no such pull-up (same reasoning
+      # as gtk-defaults's partOf = [ "sway-session.target" ] above in sway.nix).
+      after = [
+        "ssh-agent.service"
+        "sway-session.target"
+      ];
+      bindsTo = [ "ssh-agent.service" ];
+      partOf = [ "sway-session.target" ];
+      wantedBy = [
+        "ssh-agent.service"
+        "sway-session.target"
+      ];
+      # bash: the script's `#!/usr/bin/env bash` shebang needs bash resolvable
+      # via env's PATH, which systemd --user units don't get for free.
+      path = [
+        pkgs.bash
+        ssh.package
+      ];
+      # Mirrors the ssh-agent unit itself (both the socket location and the
+      # askpass wiring): without SSH_AUTH_SOCK this would talk to no agent at
+      # all, and without DISPLAY/SSH_ASKPASS a PIN-protected (verify-required)
+      # FIDO2 key has no way to prompt from this non-interactive oneshot unit.
+      environment = {
+        SSH_AUTH_SOCK = "%t/ssh-agent";
+        DISPLAY = mkIf graphical.enable "fake";
+        SSH_ASKPASS = mkIf graphical.enable "/run/current-system/sw/bin/ssh-askpass";
+      };
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = "${sshAgentAddKeysScript}/bin/ssh-agent-add-keys";
+      };
+    };
+  };
   thoughtfull.impermanence = {
     files = [
       "/etc/ssh/ssh_host_ed25519_key"

--- a/nixosModules/openssh.nix
+++ b/nixosModules/openssh.nix
@@ -121,28 +121,29 @@ in
     services.sshd-keygen.enable = mkDefault false;
     user.services.ssh-agent-add-keys = mkIf ssh.startAgent {
       description = "Load ${user.name}'s SSH auth/signing keys into ssh-agent";
-      # Two independent triggers to re-run this: ssh-agent.service (covers
-      # boot, and any agent restart) and sway-session.target (covers
-      # logout/login -- sway's nixos.conf explicitly starts/stops that target
-      # per session, so it cycles even when ssh-agent.service and the
-      # systemd --user manager itself persist across a logout). Without the
-      # second trigger, keys removed from the agent mid-session (e.g. the
-      # FIDO2 token was unplugged) never get reloaded just by logging back in.
+      # Two independent triggers to run this: ssh-agent.service (covers boot,
+      # and any agent restart) and sway-session.target (covers logging out
+      # and back into a graphical session -- sway's nixos.conf explicitly
+      # starts/stops that target per session, so it cycles even when
+      # ssh-agent.service and the systemd --user manager itself persist
+      # across a logout).
       #
-      # bindsTo only ssh-agent.service, not sway-session.target: BindsTo=
-      # implies a pull-up (like Requires=) in the direction *from* this unit,
-      # so binding to sway-session.target would drag the whole graphical
-      # session (waybar, mako, kanshi, ...) into whatever transaction starts
-      # this unit -- including the ssh-agent.service-triggered run at boot,
-      # well before sway itself is actually up on tty1. partOf only
-      # propagates stop/restart one-way, with no such pull-up (same reasoning
-      # as gtk-defaults's partOf = [ "sway-session.target" ] above in sway.nix).
+      # No RemainAfterExit: a plain oneshot resets to inactive the instant
+      # ExecStart exits, so *every* subsequent activation of either trigger
+      # -- in any order, first time or repeat -- enqueues a real start job
+      # that re-runs this. RemainAfterExit=true was tried first and doesn't
+      # work for this: once latched active by whichever trigger fires first,
+      # the other trigger's activation is a no-op against an already-active
+      # unit, so it only re-runs on a trigger's *second* activation (e.g. a
+      # second graphical logout/login), not its first -- observed on hydor as
+      # a first sway login after an earlier console login never reloading
+      # keys. The only cost of dropping it is an idempotent double-run when
+      # both triggers land in the same transaction (e.g. booting straight
+      # into a graphical session with no prior console login).
       after = [
         "ssh-agent.service"
         "sway-session.target"
       ];
-      bindsTo = [ "ssh-agent.service" ];
-      partOf = [ "sway-session.target" ];
       wantedBy = [
         "ssh-agent.service"
         "sway-session.target"
@@ -172,7 +173,6 @@ in
       };
       serviceConfig = {
         Type = "oneshot";
-        RemainAfterExit = true;
         ExecStart = "${sshAgentAddKeysScript}/bin/ssh-agent-add-keys";
       };
     };

--- a/nixosModules/openssh/ssh-agent-add-keys.bash
+++ b/nixosModules/openssh/ssh-agent-add-keys.bash
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+shopt -s nullglob
+keys=(
+  "$HOME"/.ssh/*/*_auth_@username@
+  "$HOME"/.ssh/*/*_sign_@username@
+)
+
+# Load keys one at a time so a token that's unplugged for one yubikey's stub
+# doesn't stop later (reachable) keys from being attempted. Still exits
+# nonzero -- and thus marks the unit "failed" -- if any key didn't load,
+# rather than hiding that signal behind a blanket `|| true`.
+status=0
+for key in "${keys[@]}"; do
+  ssh-add "$key" || status=1
+done
+
+exit "$status"

--- a/nixosModules/openssh/ssh-agent-add-keys.bash
+++ b/nixosModules/openssh/ssh-agent-add-keys.bash
@@ -3,8 +3,8 @@ set -euo pipefail
 
 shopt -s nullglob
 keys=(
-  "$HOME"/.ssh/*/*_auth_@username@
-  "$HOME"/.ssh/*/*_sign_@username@
+  "$HOME"/.ssh/*/*_auth_*
+  "$HOME"/.ssh/*/*_sign_*
 )
 
 # Load keys one at a time so a token that's unplugged for one yubikey's stub
@@ -13,6 +13,7 @@ keys=(
 # rather than hiding that signal behind a blanket `|| true`.
 status=0
 for key in "${keys[@]}"; do
+  [[ ${key} == *.pub ]] && continue
   ssh-add "$key" || status=1
 done
 

--- a/nixosModules/openssh/ssh-agent-add-keys.bash
+++ b/nixosModules/openssh/ssh-agent-add-keys.bash
@@ -7,6 +7,25 @@ keys=(
   "$HOME"/.ssh/*/*_sign_*
 )
 
+if loaded="$(ssh-add -L 2>/dev/null)"; then :; else loaded=""; fi
+
+# ssh-add doesn't check whether a key is already loaded before re-adding it,
+# so without this a touch/PIN-protected key already in the agent would get
+# prompted again on every run (mirrors git/git-signing-key.bash's own
+# ssh-add -L check). Compares against the key's already-committed .pub
+# companion rather than deriving one from the private key file, so this
+# never depends on that file being present/readable/well-formed.
+already_loaded() {
+  local pub
+  pub="$(cat "${1}.pub" 2>/dev/null)" || return 1
+  # -n "$pub" matters, not just -n "$loaded": grep -qF against an empty
+  # pattern matches any non-empty input, so an empty/unreadable .pub
+  # companion would otherwise read as "already loaded" -- silently and
+  # permanently skipping a key that was never actually added -- as soon as
+  # the agent has any other identity loaded at all.
+  [[ -n ${pub} && -n ${loaded} ]] && grep -qF "$(cut -d' ' -f1-2 <<<"${pub}")" <<<"${loaded}"
+}
+
 # Load keys one at a time so a token that's unplugged for one yubikey's stub
 # doesn't stop later (reachable) keys from being attempted. Still exits
 # nonzero -- and thus marks the unit "failed" -- if any key didn't load,
@@ -14,6 +33,7 @@ keys=(
 status=0
 for key in "${keys[@]}"; do
   [[ ${key} == *.pub ]] && continue
+  already_loaded "$key" && continue
   ssh-add "$key" || status=1
 done
 

--- a/tests/openssh.nix
+++ b/tests/openssh.nix
@@ -124,25 +124,21 @@ let
         && lib.elem "sway-session.target" keyLoader.wantedBy;
     }
     {
-      name = "default: ssh-agent-add-keys stops if ssh-agent stops";
-      ok = keyLoader.bindsTo == [ "ssh-agent.service" ];
-    }
-    {
-      # partOf, not bindsTo, for sway-session.target: bindsTo would pull the
-      # whole graphical session up whenever ssh-agent.service triggers this
-      # unit (e.g. at boot, well before sway itself is running).
-      name = "default: ssh-agent-add-keys follows sway-session.target down without pulling it up";
-      ok =
-        keyLoader.partOf == [ "sway-session.target" ]
-        && !(lib.elem "sway-session.target" keyLoader.bindsTo);
-    }
-    {
       name = "default: ssh-agent-add-keys talks to the same socket ssh-agent listens on";
       ok = keyLoader.environment.SSH_AUTH_SOCK == "%t/ssh-agent";
     }
     {
-      name = "default: ssh-agent-add-keys is a oneshot that stays reported as active";
-      ok = keyLoader.serviceConfig.Type == "oneshot" && keyLoader.serviceConfig.RemainAfterExit == true;
+      # No RemainAfterExit: a plain oneshot resets to inactive the instant
+      # ExecStart exits, so every subsequent activation of either trigger --
+      # in any order, first time or repeat -- actually re-runs it, rather
+      # than being a no-op against an already-active unit. See
+      # nixosModules/openssh.nix.
+      name = "default: ssh-agent-add-keys is a plain oneshot with no bindsTo/partOf";
+      ok =
+        keyLoader.serviceConfig.Type == "oneshot"
+        && !(keyLoader.serviceConfig ? RemainAfterExit)
+        && keyLoader.bindsTo == [ ]
+        && keyLoader.partOf == [ ];
     }
     {
       name = "default: ssh-agent-add-keys runs the ssh-agent-add-keys script";

--- a/tests/openssh.nix
+++ b/tests/openssh.nix
@@ -1,13 +1,19 @@
-# Lightweight nix eval check (not a nixosTest/VM boot) for the sudo PAM
-# ordering wired up in nixosModules/openssh.nix: pam_u2f (yubikey touch) tried
-# before pam_rssh (ssh-agent forwarding), with rssh scoped to the dedicated
-# sudo key file.
+# Lightweight nix eval check (not a nixosTest/VM boot) for two things wired up
+# in nixosModules/openssh.nix:
+#
+# - the sudo PAM ordering: pam_u2f (yubikey touch) tried before pam_rssh
+#   (ssh-agent forwarding), with rssh scoped to the dedicated sudo key file.
+# - the ssh-agent-add-keys systemd --user unit that loads the configured
+#   user's auth/signing keys into ssh-agent whenever it starts.
 #
 # A VM boot was considered and rejected: NixOS's PAM module renders the whole
 # /etc/pam.d/sudo file into config.security.pam.services.sudo.text at eval
 # time -- nothing about a real authentication attempt is under test here, so
 # reading that string directly gives byte-for-byte the same content a VM's
-# `cat /etc/pam.d/sudo` would, without needing to boot anything.
+# `cat /etc/pam.d/sudo` would, without needing to boot anything. Likewise, the
+# unit's After/WantedBy/ExecStart are plain eval-time config values -- no need
+# to boot a VM (and actually loading keys needs a real ssh-agent socket and a
+# FIDO2 token anyway, which a VM test can't provide).
 { self, nixpkgs, ... }:
 let
   inherit (nixpkgs) lib;
@@ -19,37 +25,61 @@ let
     };
   };
 
-  eval = nixosSystem {
-    system = nixpkgs.stdenv.hostPlatform.system;
-    lib = self.lib;
-    specialArgs = {
-      inputs = self.inputs // {
-        inherit self;
+  # Shared eval scaffolding, parameterized by an extra module so each variant
+  # below only has to state what it overrides relative to the default host.
+  mkEval =
+    extraModule:
+    nixosSystem {
+      system = nixpkgs.stdenv.hostPlatform.system;
+      lib = self.lib;
+      specialArgs = {
+        inputs = self.inputs // {
+          inherit self;
+        };
       };
+      modules = [
+        defaultModule
+        (
+          { lib, ... }:
+          {
+            # thoughtfull.user.name has no default and must be set for eval to
+            # succeed; this test's checks don't depend on its particular value
+            thoughtfull.user.name = "technosophist";
+            # clear module-set nixpkgs.config to avoid the "external pkgs instance" assertion
+            nixpkgs.config = lib.mkForce { };
+            # openssh.nix disables automatic keygen; re-enable to mirror a real host
+            systemd.services.sshd-keygen.enable = lib.mkForce true;
+            # Disable services that need secrets or required options not suitable for eval
+            services.syncthing.enable = lib.mkForce false;
+            services.restic.thoughtfull.enable = lib.mkForce false;
+            thoughtfull = {
+              impermanence.enable = lib.mkForce false;
+              monitoring.enable = lib.mkForce false;
+            };
+          }
+        )
+        extraModule
+      ];
     };
-    modules = [
-      defaultModule
-      (
-        { lib, ... }:
-        {
-          # thoughtfull.user.name has no default and must be set for eval to
-          # succeed; this test's checks don't depend on its particular value
-          thoughtfull.user.name = "technosophist";
-          # clear module-set nixpkgs.config to avoid the "external pkgs instance" assertion
-          nixpkgs.config = lib.mkForce { };
-          # openssh.nix disables automatic keygen; re-enable to mirror a real host
-          systemd.services.sshd-keygen.enable = lib.mkForce true;
-          # Disable services that need secrets or required options not suitable for eval
-          services.syncthing.enable = lib.mkForce false;
-          services.restic.thoughtfull.enable = lib.mkForce false;
-          thoughtfull = {
-            impermanence.enable = lib.mkForce false;
-            monitoring.enable = lib.mkForce false;
-          };
-        }
-      )
-    ];
-  };
+
+  eval = mkEval ({ ... }: { });
+
+  # graphical.enable pulls in the askpass wiring on the key-loader unit.
+  graphicalEval = mkEval (
+    { lib, ... }:
+    {
+      thoughtfull.graphical.enable = lib.mkForce true;
+    }
+  );
+
+  # startAgent = false must remove the key-loader unit entirely -- it's
+  # wanted/bound to a ssh-agent.service that no longer exists in this case.
+  noAgentEval = mkEval (
+    { lib, ... }:
+    {
+      programs.ssh.startAgent = lib.mkForce false;
+    }
+  );
 
   pamSudoLines = lib.splitString "\n" eval.config.security.pam.services.sudo.text;
   indexed = lib.imap0 (i: line: { inherit i line; }) pamSudoLines;
@@ -58,6 +88,8 @@ let
   ) indexed;
   u2fEntries = builtins.filter (e: lib.hasInfix "pam_u2f.so" e.line) indexed;
   rsshEntries = builtins.filter (e: lib.hasInfix "libpam_rssh.so" e.line) indexed;
+
+  keyLoader = eval.config.systemd.user.services.ssh-agent-add-keys;
 
   checks = [
     {
@@ -77,6 +109,80 @@ let
         rsshEntries != [ ]
         && lib.hasInfix "auth_key_file=/etc/ssh/authorized_keys.d/\${ruser}_sudo" (builtins.head rsshEntries)
         .line;
+    }
+    {
+      # Static wiring only -- this doesn't (and can't, at eval time) verify
+      # that logging out and back in actually re-runs the unit; that rests on
+      # runtime systemd transaction semantics (sway's nixos.conf starting and
+      # stopping sway-session.target once per session) described in
+      # nixosModules/openssh.nix.
+      name = "default: ssh-agent-add-keys starts alongside and after ssh-agent and each sway session";
+      ok =
+        lib.elem "ssh-agent.service" keyLoader.after
+        && lib.elem "sway-session.target" keyLoader.after
+        && lib.elem "ssh-agent.service" keyLoader.wantedBy
+        && lib.elem "sway-session.target" keyLoader.wantedBy;
+    }
+    {
+      name = "default: ssh-agent-add-keys stops if ssh-agent stops";
+      ok = keyLoader.bindsTo == [ "ssh-agent.service" ];
+    }
+    {
+      # partOf, not bindsTo, for sway-session.target: bindsTo would pull the
+      # whole graphical session up whenever ssh-agent.service triggers this
+      # unit (e.g. at boot, well before sway itself is running).
+      name = "default: ssh-agent-add-keys follows sway-session.target down without pulling it up";
+      ok =
+        keyLoader.partOf == [ "sway-session.target" ]
+        && !(lib.elem "sway-session.target" keyLoader.bindsTo);
+    }
+    {
+      name = "default: ssh-agent-add-keys talks to the same socket ssh-agent listens on";
+      ok = keyLoader.environment.SSH_AUTH_SOCK == "%t/ssh-agent";
+    }
+    {
+      name = "default: ssh-agent-add-keys is a oneshot that stays reported as active";
+      ok = keyLoader.serviceConfig.Type == "oneshot" && keyLoader.serviceConfig.RemainAfterExit == true;
+    }
+    {
+      name = "default: ssh-agent-add-keys runs the ssh-agent-add-keys script";
+      ok = lib.hasInfix "/bin/ssh-agent-add-keys" keyLoader.serviceConfig.ExecStart;
+    }
+    {
+      name = "graphical: ssh-agent-add-keys gets DISPLAY/SSH_ASKPASS for PIN-protected keys";
+      ok =
+        let
+          env = graphicalEval.config.systemd.user.services.ssh-agent-add-keys.environment;
+        in
+        env.DISPLAY == "fake" && env.SSH_ASKPASS == "/run/current-system/sw/bin/ssh-askpass";
+    }
+    {
+      name = "no agent: ssh-agent-add-keys does not exist when startAgent is disabled";
+      ok = !(noAgentEval.config.systemd.user.services ? ssh-agent-add-keys);
+    }
+    {
+      # Covers the console-login gap the systemd unit alone can't: neither of
+      # its triggers (ssh-agent.service, sway-session.target) fires for a
+      # plain console re-login while the systemd --user manager persists
+      # across logout.
+      name = "default: loginShellInit loads keys on the terminal, not via GUI askpass";
+      ok =
+        lib.hasInfix "SSH_ASKPASS_REQUIRE=never" eval.config.environment.loginShellInit
+        && lib.hasInfix "/bin/ssh-agent-add-keys" eval.config.environment.loginShellInit
+        && !(lib.hasInfix "/dev/tty1" eval.config.environment.loginShellInit);
+    }
+    {
+      # tty1 is where sway autologins -- that case is deferred to the
+      # ssh-agent-add-keys unit's sway-session.target trigger instead (see
+      # nixosModules/openssh.nix), so it shouldn't also run here.
+      name = "graphical: loginShellInit skips the console load path on tty1";
+      ok =
+        lib.hasInfix "/dev/tty1" graphicalEval.config.environment.loginShellInit
+        && lib.hasInfix "SSH_ASKPASS_REQUIRE=never" graphicalEval.config.environment.loginShellInit;
+    }
+    {
+      name = "no agent: loginShellInit doesn't try to load keys when startAgent is disabled";
+      ok = !(lib.hasInfix "ssh-agent-add-keys" noAgentEval.config.environment.loginShellInit);
     }
   ];
 

--- a/tests/openssh.nix
+++ b/tests/openssh.nix
@@ -149,12 +149,17 @@ let
       ok = lib.hasInfix "/bin/ssh-agent-add-keys" keyLoader.serviceConfig.ExecStart;
     }
     {
-      name = "graphical: ssh-agent-add-keys gets DISPLAY/SSH_ASKPASS for PIN-protected keys";
+      # No DISPLAY assertion: it's deliberately left unset here so the unit
+      # inherits whatever the systemd --user manager's environment already
+      # has (a real DISPLAY once sway imports it, nothing at boot) -- a
+      # placeholder value wouldn't let the askpass helper actually open a
+      # window. See nixosModules/openssh.nix.
+      name = "graphical: ssh-agent-add-keys gets SSH_ASKPASS for PIN-protected keys";
       ok =
         let
           env = graphicalEval.config.systemd.user.services.ssh-agent-add-keys.environment;
         in
-        env.DISPLAY == "fake" && env.SSH_ASKPASS == "/run/current-system/sw/bin/ssh-askpass";
+        !(env ? DISPLAY) && env.SSH_ASKPASS == "/run/current-system/sw/bin/ssh-askpass";
     }
     {
       name = "no agent: ssh-agent-add-keys does not exist when startAgent is disabled";


### PR DESCRIPTION
## Summary
- Add a `ssh-agent-add-keys` systemd `--user` unit and a companion `loginShellInit` login hook that together load SSH key stubs into `ssh-agent` on login -- glob-matched from `~/.ssh/*/*_auth_*` and `~/.ssh/*/*_sign_*` (excluding `.pub` files), one `~/.ssh/<yubikey>/` directory per YubiKey (primary and backup).
- The systemd unit covers the graphical case: triggered by both `ssh-agent.service` (boot, agent restart) and `sway-session.target` (logging out and back into a graphical session). It's a plain oneshot with no `RemainAfterExit` (and no `bindsTo`/`partOf`): it resets to inactive the instant it exits, so *every* subsequent activation of either trigger -- in any order, first time or repeat -- actually re-runs it. (`RemainAfterExit=true` was tried first and doesn't work: once latched active by whichever trigger fires first, the other trigger's first activation is a no-op against an already-active unit -- confirmed on hydor's boot journal as "keys load on console login, then never load on the first login into sway".)
- `SSH_ASKPASS` is set explicitly for the askpass helper; `DISPLAY` is deliberately left unset so the unit inherits the real value sway's `nixos.conf` imports into the systemd `--user` manager's environment ahead of starting `sway-session.target` (same as waybar/mako/kanshi) -- a placeholder `DISPLAY` wouldn't let the askpass helper actually open a window.
- `loginShellInit` covers plain console logins, which neither systemd trigger reaches while the systemd `--user` manager persists across logout (which it can even without lingering enabled): it runs the loader directly in the login shell, connected to that shell's own terminal, forcing `SSH_ASKPASS_REQUIRE=never` so it prompts on the console instead of trying to pop a GUI helper with no display to render on. It skips tty1 (where sway autologins), deferring that case to the systemd unit's properly-timed retry.
- `ssh-add` loads keys one at a time so a token that's unplugged for one yubikey's stub doesn't stop other (reachable) keys from being attempted, while still surfacing a nonzero/failed status if any key didn't load.
- Since `loginShellInit` reruns on every login shell (not just once after boot -- e.g. every interactive `ssh` into the host), and `ssh-add` doesn't check whether a key is already loaded before re-adding it, an `already_loaded()` check (mirroring `git/git-signing-key.bash`'s own `ssh-add -L` check) skips re-adding a key already present in the agent, so a touch/PIN-protected key doesn't get re-prompted on every login.
- Both units are gated on `programs.ssh.startAgent`; the askpass wiring is only enabled when `thoughtfull.graphical.enable` is set.
- Adds eval-based coverage in `tests/openssh.nix` for the unit's ordering/environment/service config, the `graphical.enable` and `startAgent = false` branches, and the `loginShellInit` content for each case.
- Documents in `README.md` how to provision the key stubs onto a machine via `ssh-keygen -K`, since nothing in this repo otherwise creates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)