### PR TITLE
Launch foot/firefox/slack/emacs on fixed workspaces at login

### DIFF
--- a/nixosModules/emacs.nix
+++ b/nixosModules/emacs.nix
@@ -5,6 +5,7 @@
   ...
 }:
 let
+  inherit (config.programs) sway;
   inherit (config.thoughtfull) graphical;
   inherit (lib) mkDefault mkIf mkOption;
   inherit (lib.thoughtfull.types) selectorFunction;
@@ -12,13 +13,23 @@ let
   inherit (pkgs)
     aspell
     aspellDicts
+    bash
     emacs
     emacs-all-the-icons-fonts
     silver-searcher
     unzip
     ;
-  inherit (pkgs.thoughtfull) writeFile;
+  inherit (pkgs.thoughtfull) writeFile writeFileScript;
   cfg = config.services.emacs;
+  login = writeFileScript {
+    name = "emacs-client-login";
+    replacements = {
+      bash = "${bash}/bin/bash";
+      emacsclient = "${cfg.package}/bin/emacsclient";
+      swaymsg = "${sway.package}/bin/swaymsg";
+    };
+    src = ./emacs/login.bash;
+  };
 in
 {
   config = {
@@ -59,6 +70,40 @@ in
       startWithGraphical = mkDefault graphical.enable;
     };
     thoughtfull.impermanence.user.directories = mkIf cfg.enable [ ".config/emacs" ];
+    systemd.user.services.emacs-client-login = {
+      description = "Open an emacs frame on workspace 2 at login";
+      # Ordered after emacs.service itself (not just sway-session.target) so
+      # this doesn't even attempt emacsclient before the daemon exists; see
+      # emacs/login.bash for why that also means no retry is needed here.
+      after = [
+        "sway-session.target"
+        "emacs.service"
+        "waybar.service"
+      ];
+      wants = [ "emacs.service" ];
+      # See gtk-defaults in sway.nix for why partOf (follow sway-session
+      # down) rather than bindsTo (would also pull sway-session.target up on
+      # a lone `systemctl --user start emacs-client-login.service`, which
+      # isn't wanted here). Deliberately not partOf emacs.service: the
+      # daemon's own lifecycle (e.g. surviving a crash-restart) is
+      # independent of this one-off login trigger.
+      partOf = [ "sway-session.target" ];
+      enable = mkDefault (sway.enable && cfg.enable);
+      wantedBy = [ "sway-session.target" ];
+      # A rebuild-switch that touches this unit's closure (e.g. an
+      # emacs/sway package bump) shouldn't reopen a frame mid-session.
+      # (No KillMode=process here unlike foot/firefox/slack-login: this
+      # script doesn't background anything, it just tells the daemon to
+      # create a frame and exits, so nothing of the frame lives in this
+      # unit's control group to begin with.)
+      restartIfChanged = mkDefault false;
+      serviceConfig = {
+        Type = "oneshot";
+        # See foot-login in foot.nix for why oneshot + RemainAfterExit here.
+        RemainAfterExit = true;
+        ExecStart = "${login}";
+      };
+    };
   };
   options.services.emacs.thoughtfull = {
     extraConfig = mkOption {

--- a/nixosModules/emacs/login.bash
+++ b/nixosModules/emacs/login.bash
@@ -1,0 +1,16 @@
+#!@bash@
+set -euo pipefail
+
+# Unlike foot/firefox/slack, emacsclient doesn't own the window itself -- the
+# long-running daemon does -- so pid matching would keep matching every
+# future frame that daemon ever creates, not just this one. Tagging this one
+# frame with a name and matching on that title instead is what makes this
+# self-expire the way pid=$! does for the others: later `emacsclient -c`
+# calls (without this frame name) never match.
+#
+# No retry here: emacs-client-login.service (../emacs.nix) orders this after
+# emacs.service and emacs.service is Type=notify, so systemd itself already
+# blocks starting this unit until the daemon signals it's ready to accept
+# clients -- there's no readiness gap left for a retry to cover.
+@swaymsg@ "for_window [title=^login-emacs$] move to workspace 2"
+@emacsclient@ -c -F '((name . "login-emacs"))'

--- a/nixosModules/firefox.nix
+++ b/nixosModules/firefox.nix
@@ -5,9 +5,19 @@
   ...
 }:
 let
-  inherit (config.programs) firefox;
-  inherit (lib) mkIf;
-  inherit (pkgs) ibm-plex;
+  inherit (config.programs) firefox sway;
+  inherit (lib) mkDefault mkIf;
+  inherit (pkgs) bash ibm-plex;
+  inherit (pkgs.thoughtfull) writeFileScript;
+  login = writeFileScript {
+    name = "firefox-login";
+    replacements = {
+      bash = "${bash}/bin/bash";
+      firefox = "${firefox.finalPackage}/bin/firefox";
+      swaymsg = "${sway.package}/bin/swaymsg";
+    };
+    src = ./firefox/login.bash;
+  };
 in
 {
   fonts.packages = mkIf firefox.enable [ ibm-plex ];
@@ -109,4 +119,29 @@ in
     };
   };
   thoughtfull.impermanence.user.directories = mkIf firefox.enable [ ".config/mozilla/firefox" ];
+  systemd.user.services.firefox-login = {
+    description = "Launch firefox on workspace 3 at login";
+    after = [
+      "sway-session.target"
+      "waybar.service"
+    ];
+    # See gtk-defaults in sway.nix for why partOf (follow sway-session down)
+    # rather than bindsTo (would also pull sway-session.target up on a lone
+    # `systemctl --user start firefox-login.service`, which isn't wanted
+    # here).
+    partOf = [ "sway-session.target" ];
+    enable = mkDefault (sway.enable && firefox.enable);
+    wantedBy = [ "sway-session.target" ];
+    # A rebuild-switch that touches this unit's closure (e.g. a firefox/sway
+    # package bump) shouldn't relaunch firefox mid-session.
+    restartIfChanged = mkDefault false;
+    serviceConfig = {
+      Type = "oneshot";
+      # See foot-login in foot.nix for why oneshot + RemainAfterExit, and
+      # for KillMode=process, here.
+      RemainAfterExit = true;
+      KillMode = "process";
+      ExecStart = "${login}";
+    };
+  };
 }

--- a/nixosModules/firefox/login.bash
+++ b/nixosModules/firefox/login.bash
@@ -1,0 +1,11 @@
+#!@bash@
+set -euo pipefail
+
+# See ../foot/login.bash for why pid=$! (not swaymsg's own) is what places
+# the window without pinning firefox to this workspace afterward. If an
+# instance is already running, firefox hands off to it and exits almost
+# immediately without mapping its own window -- $! then names a dead end and
+# this silently misses, which is a known gap (see firefox-login.service in
+# ../firefox.nix), not something this script can detect or fix.
+@firefox@ &
+@swaymsg@ "for_window [pid=$!] move to workspace 3"

--- a/nixosModules/foot.nix
+++ b/nixosModules/foot.nix
@@ -5,10 +5,12 @@
   ...
 }:
 let
+  inherit (config.programs) sway;
   inherit (config.thoughtfull) graphical;
   inherit (lib) mkDefault;
   inherit (pkgs) bash foot;
-  inherit (pkgs.thoughtfull) theme-toggle writeFileScriptBin;
+  inherit (pkgs.thoughtfull) theme-toggle writeFileScript writeFileScriptBin;
+  cfg = config.programs.foot;
   footWrapper = writeFileScriptBin {
     name = "foot";
     replacements = {
@@ -17,6 +19,15 @@ let
       theme-get = "${theme-toggle}/bin/theme-get";
     };
     src = ./foot/wrapper.bash;
+  };
+  login = writeFileScript {
+    name = "foot-login";
+    replacements = {
+      bash = "${bash}/bin/bash";
+      foot = "${cfg.package}/bin/foot";
+      swaymsg = "${sway.package}/bin/swaymsg";
+    };
+    src = ./foot/login.bash;
   };
 in
 {
@@ -67,6 +78,42 @@ in
         bright6 = mkDefault "33c7de";
         bright7 = mkDefault "ffffff";
       };
+    };
+  };
+  systemd.user.services.foot-login = {
+    description = "Launch foot on workspace 1 at login";
+    after = [
+      "sway-session.target"
+      "waybar.service"
+    ];
+    # See gtk-defaults in sway.nix for why partOf (follow sway-session down)
+    # rather than bindsTo (would also pull sway-session.target up on a lone
+    # `systemctl --user start foot-login.service`, which isn't wanted here).
+    partOf = [ "sway-session.target" ];
+    enable = mkDefault (sway.enable && cfg.enable);
+    wantedBy = [ "sway-session.target" ];
+    # A rebuild-switch that touches this unit's closure (e.g. a foot/sway
+    # package bump) shouldn't relaunch foot mid-session.
+    restartIfChanged = mkDefault false;
+    serviceConfig = {
+      Type = "oneshot";
+      # Type=oneshot means quitting foot later can't retroactively fail this
+      # unit -- its result is fixed the moment login.bash's `swaymsg` call
+      # returns. RemainAfterExit keeps it showing active/exited rather than
+      # inactive (dead) once that's happened, same reasoning as gtk-defaults.
+      RemainAfterExit = true;
+      # login.bash backgrounds foot and exits, so the actual foot process
+      # stays in this unit's control group after ExecStart returns.
+      # KillMode's default (control-group) would mean any stop of this unit
+      # -- including partOf's propagation from `systemctl --user stop
+      # sway-session.target` on every sway exit, or just a manual
+      # `systemctl --user restart foot-login.service` -- kills that already
+      # running foot window, not just (the long-since-exited) launcher
+      # script. KillMode=process only signals the tracked main process,
+      # which for a oneshot is gone by the time anyone stops the unit, so
+      # this reaches nothing.
+      KillMode = "process";
+      ExecStart = "${login}";
     };
   };
 }

--- a/nixosModules/foot/login.bash
+++ b/nixosModules/foot/login.bash
@@ -1,0 +1,9 @@
+#!@bash@
+set -euo pipefail
+
+# Registering the for_window rule against this exact pid (not swaymsg's own,
+# which never owns a window) is what places the new window without
+# permanently pinning foot to this workspace -- see foot-login.service in
+# ../foot.nix for how this only ever runs once, at login.
+@foot@ &
+@swaymsg@ "for_window [pid=$!] move to workspace 1"

--- a/nixosModules/slack.nix
+++ b/nixosModules/slack.nix
@@ -5,9 +5,21 @@
   ...
 }:
 let
+  inherit (config.programs) sway;
   inherit (config.thoughtfull) graphical;
   inherit (config.thoughtfull.programs) slack;
-  inherit (lib) mkEnableOption mkIf;
+  inherit (lib) mkDefault mkEnableOption mkIf;
+  inherit (pkgs) bash;
+  inherit (pkgs.thoughtfull) writeFileScript;
+  login = writeFileScript {
+    name = "slack-login";
+    replacements = {
+      bash = "${bash}/bin/bash";
+      slack = "${pkgs.slack}/bin/slack";
+      swaymsg = "${sway.package}/bin/swaymsg";
+    };
+    src = ./slack/login.bash;
+  };
 in
 {
   config = {
@@ -18,6 +30,31 @@ in
         mode = "0700";
       }
     ];
+    systemd.user.services.slack-login = {
+      description = "Launch slack on workspace 4 at login";
+      after = [
+        "sway-session.target"
+        "waybar.service"
+      ];
+      # See gtk-defaults in sway.nix for why partOf (follow sway-session
+      # down) rather than bindsTo (would also pull sway-session.target up on
+      # a lone `systemctl --user start slack-login.service`, which isn't
+      # wanted here).
+      partOf = [ "sway-session.target" ];
+      enable = mkDefault (sway.enable && slack.enable);
+      wantedBy = [ "sway-session.target" ];
+      # A rebuild-switch that touches this unit's closure (e.g. a slack/sway
+      # package bump) shouldn't relaunch slack mid-session.
+      restartIfChanged = mkDefault false;
+      serviceConfig = {
+        Type = "oneshot";
+        # See foot-login in foot.nix for why oneshot + RemainAfterExit, and
+        # for KillMode=process, here.
+        RemainAfterExit = true;
+        KillMode = "process";
+        ExecStart = "${login}";
+      };
+    };
   };
   options.thoughtfull.programs.slack.enable = mkEnableOption "slack" // {
     default = graphical.enable;

--- a/nixosModules/slack/login.bash
+++ b/nixosModules/slack/login.bash
@@ -1,0 +1,12 @@
+#!@bash@
+set -euo pipefail
+
+# See ../foot/login.bash for why pid=$! (not swaymsg's own) is what places
+# the window without pinning slack to this workspace afterward. If an
+# instance is already running, slack (Electron's single-instance lock) hands
+# off to it and exits almost immediately without mapping its own window --
+# $! then names a dead end and this silently misses, which is a known gap
+# (see slack-login.service in ../slack.nix), not something this script can
+# detect or fix.
+@slack@ &
+@swaymsg@ "for_window [pid=$!] move to workspace 4"


### PR DESCRIPTION
## Summary

- Adds a `systemd.user.services.*-login` oneshot unit per app (`foot.nix`, `firefox.nix`, `slack.nix`, `emacs.nix`) that launches it and places it on a fixed workspace (1/3/4/2 respectively) once, at login only — not on `sway reload`, and without permanently pinning the app to that workspace (quit and relaunch it anywhere afterward).
- Each unit is ordered explicitly after `sway-session.target` and `waybar.service` (`emacs-client-login` also after `emacs.service`, via a real `Wants=`/`After=` dependency rather than a manual `systemctl start` call from within a script), instead of relying on sway's own `exec`/`config.d`-include ordering.
- Each unit's `ExecStart` is a small standalone script invoked by its exact store path with no arguments (`foot/login.bash`, `firefox/login.bash`, `slack/login.bash`, `emacs/login.bash`), rather than a shell one-liner threaded through sway's config parser, sway's IPC command parser, and a shell — this avoids a class of nested-quoting bugs that a prior iteration of this feature (raw sway `exec` lines) kept hitting.
- Placement works by registering a `for_window` rule matched against the launched process's own pid (or, for emacs, a one-off frame title, since `emacsclient` doesn't own the window — the daemon does). The match fires whenever the window actually maps, regardless of which workspace is focused at that moment, so there's no race with slow-starting apps. It also self-expires: pids aren't reused across relaunches, and later `emacsclient -c` calls won't carry the one-off frame title.
- Units are `Type=oneshot` + `RemainAfterExit=true` so quitting the app later can't retroactively fail the unit (its result is fixed once the launch script's `swaymsg` call returns), and `partOf = ["sway-session.target"]` so they stop with the session and rerun on the next login.
- `foot-login`/`firefox-login`/`slack-login` also set `KillMode = "process"`: their scripts background the actual app and exit, so it stays in the unit's control group after `ExecStart` returns. The default `KillMode` (`control-group`) would mean any stop of the unit — including `partOf`'s propagation from `systemctl --user stop sway-session.target` on every sway exit, or a manual `systemctl --user restart foot-login.service` — kills that already-running app, not just the long-since-exited launcher script. `KillMode=process` only signals the tracked main process, which for a oneshot is already gone by the time anyone stops the unit, so this reaches nothing. Not needed on `emacs-client-login`: it doesn't background anything, it just tells the daemon to create a frame and exits, so nothing of the frame lives in this unit's control group to begin with.
- All four also set `restartIfChanged = false`, so a rebuild-switch that touches a unit's closure (an app or sway package bump) doesn't relaunch/reopen anything mid-session.

## Known limitations

- If firefox or slack is already running when the unit fires (e.g. a stray process left over from testing via `reload` rather than a full logout), both apps hand off to the existing instance and exit almost immediately without mapping their own window — the `pid=$!` criterion then names a dead end and placement is silently missed. Doesn't affect a genuine cold login.
- A sway `reload` mid-launch (between the app process starting and its window actually mapping) drops that one launch's placement rule for the rest of the session, since `reload` rebuilds sway's runtime `for_window` criteria from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)