### PR TITLE
Bind waybar's lifecycle to sway-session.target

### DIFF
--- a/nixosModules/sway/waybar.nix
+++ b/nixosModules/sway/waybar.nix
@@ -79,6 +79,16 @@ in
         # (nixosModules/sway.nix), so waiting on the target alone already
         # guarantees the GTK theme is applied before this starts.
         after = [ "sway-session.target" ];
+        # The packaged unit only carries PartOf=graphical-session.target, a
+        # target this repo's sway integration never stops on logout (only
+        # sway-session.target is stopped -- see nixosModules/sway/nixos.conf).
+        # Without this, waybar survives logout still attached to the dying
+        # session's Wayland socket, then dies once that socket actually
+        # closes and respawns (Restart=on-failure) into a stale environment,
+        # looping until systemd's start-limit kills it -- so it never comes
+        # back on the next login. Same pattern as sway-autotiling/xremap
+        # below.
+        bindsTo = [ "sway-session.target" ];
         path = [
           bash
           curl

--- a/nixosModules/sway/waybar.nix
+++ b/nixosModules/sway/waybar.nix
@@ -86,8 +86,8 @@ in
         # session's Wayland socket, then dies once that socket actually
         # closes and respawns (Restart=on-failure) into a stale environment,
         # looping until systemd's start-limit kills it -- so it never comes
-        # back on the next login. Same pattern as sway-autotiling/xremap
-        # below.
+        # back on the next login. Same pattern as sway-autotiling/xremap in
+        # nixosModules/sway.nix and kanshi in nixosModules/sway/kanshi.nix.
         bindsTo = [ "sway-session.target" ];
         path = [
           bash

--- a/tests/waybar.nix
+++ b/tests/waybar.nix
@@ -628,6 +628,25 @@ testPkgs.testers.nixosTest {
             "waybar should be ordered After=sway-session.target"
         )
 
+    with subtest("waybar is bound to sway-session.target's lifecycle"):
+        # Regression test: waybar's packaged unit only carries
+        # PartOf=graphical-session.target, a target this repo's sway
+        # integration never stops on logout (only sway-session.target is
+        # stopped -- see nixosModules/sway/nixos.conf). Without a matching
+        # BindsTo=sway-session.target here (the same pattern already used by
+        # sway-autotiling/xremap in nixosModules/sway.nix), waybar survives
+        # logout attached to the dying session's Wayland socket, then dies
+        # with "Connection reset by peer" once that socket actually closes.
+        # Restart=on-failure respawns it into a now-stale environment
+        # ("cannot open display: :0"), looping until systemd's start-limit
+        # kills the service -- so on the next login waybar never starts.
+        dropin = machine.succeed("cat /etc/systemd/user/waybar.service.d/*.conf")
+        assert "BindsTo=sway-session.target" in dropin, (
+            "waybar should be BindsTo=sway-session.target, so stopping the "
+            "session target actually stops waybar instead of leaving it "
+            "running against a dead compositor socket"
+        )
+
     with subtest("nm-applet is removed"):
         machine.fail("test -f /etc/systemd/user/nm-applet.service")
 


### PR DESCRIPTION
## Problem

Waybar starts fine on first boot/login, but after a logout and relogin, it fails to start — spinning through `Restart=on-failure` retries until systemd's start-limit kills the service. Live logs from the affected machine (`hydor`):

```
Aug 01 16:06:51 hydor waybar[2965]: [info] Bar configured (width: 1920, height: 30) for output: eDP-1
Aug 01 16:07:01 hydor waybar[2965]: Error reading events from display: Connection reset by peer
Aug 01 16:07:01 hydor systemd[2721]: waybar.service: Main process exited, code=exited, status=1/FAILURE
Aug 01 16:07:01 hydor waybar[3328]: cannot open display: :0
...
Aug 01 16:07:02 hydor systemd[2721]: waybar.service: Start request repeated too quickly.
Aug 01 16:07:02 hydor systemd[2721]: waybar.service: Failed with result 'start-limit-hit'.
```

## Root cause

Waybar's packaged unit (`programs.waybar`, from nixpkgs) only carries `PartOf=graphical-session.target` in `[Unit]`. This repo's sway integration never starts or stops `graphical-session.target` — it manages a custom `sway-session.target` instead, stopped on logout via `nixosModules/sway/nixos.conf`'s `systemctl --user stop sway-session.target`.

Because waybar was only `WantedBy=sway-session.target` (pull-in on start) with no matching stop-binding, stopping `sway-session.target` on logout never stopped waybar. It survived, still attached to the dying session's Wayland socket, until that socket actually closed ("Connection reset by peer"). `Restart=on-failure` then respawned it into a stale environment (`cannot open display: :0`), looping until systemd's start-limit killed the service — so waybar never came back on the next login.

## Fix

Add `bindsTo = [ "sway-session.target" ];` to waybar's `systemd.user.services` definition in `nixosModules/sway/waybar.nix`, matching the pattern already used by `sway-autotiling`/`xremap` in `nixosModules/sway.nix`. This makes systemd stop waybar whenever `sway-session.target` stops, so each login starts a fresh waybar process with a fresh environment instead of an orphaned one from the previous session.

## Testing

Added a regression subtest to `tests/waybar.nix` asserting `BindsTo=sway-session.target` is present in the rendered drop-in unit. Confirmed it fails against the old module and passes after the fix; full `waybar` test suite passes.

Note: this was verified via the unit's dependency graph in the NixOS VM test, not a live logout/login on real hardware — worth confirming on `hydor` after deploy. If waybar is currently wedged in `start-limit-hit` there, a rebuild+switch alone won't clear it in the live session; run `systemctl --user reset-failed waybar.service` or do one more logout/login after deploying.