### PR TITLE
system-pull: re-verify connectivity live before pulling

### DIFF
--- a/nixosModules/system-pull.nix
+++ b/nixosModules/system-pull.nix
@@ -40,6 +40,14 @@ in
 
     systemd.services.system-pull = {
       description = mkDefault "Pull the latest system closure from the binary cache";
+      # network-online.target is satisfied once at boot by
+      # NetworkManager-wait-online.service (Type=oneshot, RemainAfterExit=yes)
+      # and never re-checked afterwards. On a laptop that suspends, the target
+      # stays "active" straight through sleep/resume, so this ordering is a
+      # no-op after boot: if the daily timer's Persistent= catch-up run fires
+      # right on wake (Wi-Fi not yet reassociated), nothing here blocks it.
+      # Kept anyway because it is still correct at boot; the live check below
+      # (ExecStartPre) is what actually guards against the stale-target case.
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
       restartIfChanged = mkDefault false;
@@ -66,6 +74,13 @@ in
         # switch the script runs in-process. The script takes no arguments; its
         # bucket, region, and credentials path are baked in above.
         ExecStart = mkDefault "/run/current-system/sw/bin/system-pull";
+        # Re-verify connectivity live on every start, since network-online.target
+        # (see comment above) can be stale after resume. `nm-online` without -s
+        # does a fresh check for an actual active connection (unlike -s, which
+        # only checks the one-time boot startup milestone and would reproduce
+        # the same staleness bug). Referenced through /run/current-system for
+        # the same byte-identical-unit reason as ExecStart above.
+        ExecStartPre = mkDefault "/run/current-system/sw/bin/nm-online -q -t 60";
       };
     };
 

--- a/nixosModules/system-pull.nix
+++ b/nixosModules/system-pull.nix
@@ -89,8 +89,21 @@ in
         # ExecStartPre fail on those hosts before ExecStart ever runs,
         # breaking every system-pull run rather than just the suspend/resume
         # race this is meant to fix.
+        #
+        # No -q: if this times out, we want nm-online's own diagnostic (which
+        # connectivity state it was stuck in) in `journalctl -u system-pull`,
+        # not just a bare "ExecStartPre failed with exit code 1" -- this whole
+        # fix came out of having to dig through logs once already. A generous
+        # 5-minute timeout (nm-online polls internally, so this doubles as the
+        # retry) covers a slow Wi-Fi reassociation on wake; nothing else waits
+        # on this oneshot (it's timer-triggered, not in the boot path), and
+        # Type=oneshot disables TimeoutStartSec by default, so there's no
+        # competing systemd start-timeout to race against. A wait genuinely
+        # longer than that (captive portal, no network at all) needs a human
+        # regardless, so failing and alerting rather than retrying further is
+        # correct -- the daily timer catches the next scheduled run anyway.
         ExecStartPre = mkIf config.networking.networkmanager.enable (
-          mkDefault "/run/current-system/sw/bin/nm-online -q -t 60"
+          mkDefault "/run/current-system/sw/bin/nm-online -t 300"
         );
       };
     };

--- a/nixosModules/system-pull.nix
+++ b/nixosModules/system-pull.nix
@@ -80,7 +80,18 @@ in
         # only checks the one-time boot startup milestone and would reproduce
         # the same staleness bug). Referenced through /run/current-system for
         # the same byte-identical-unit reason as ExecStart above.
-        ExecStartPre = mkDefault "/run/current-system/sw/bin/nm-online -q -t 60";
+        #
+        # Only wired up when NetworkManager is actually enabled: nm-online is
+        # only installed onto the system PATH by NixOS's networkmanager module
+        # (environment.systemPackages), and hosts like the rpi4-based ones
+        # force networkmanager.enable = false / useNetworkd = true (see
+        # rpi4.nix). Referencing nm-online unconditionally would make
+        # ExecStartPre fail on those hosts before ExecStart ever runs,
+        # breaking every system-pull run rather than just the suspend/resume
+        # race this is meant to fix.
+        ExecStartPre = mkIf config.networking.networkmanager.enable (
+          mkDefault "/run/current-system/sw/bin/nm-online -q -t 60"
+        );
       };
     };
 

--- a/tests/system-pull.nix
+++ b/tests/system-pull.nix
@@ -48,10 +48,24 @@ let
   );
   # No credentials => systemPull default is false, no timer/service.
   noCredentials = mkEval { thoughtfull.binaryCache.awsCredentialsFile = null; };
+  # NetworkManager explicitly enabled (e.g. hydor via graphical.nix): nm-online
+  # is guaranteed to be installed, so the live connectivity check should apply.
+  # `headless` deliberately leaves NetworkManager off (its default), standing
+  # in for hosts like tislit -- rpi4.nix forces networkmanager.enable = false
+  # and useNetworkd = true, so nm-online is never installed there and
+  # referencing it unconditionally would make every system-pull run fail.
+  networkManager = mkEval (
+    { pkgs, ... }:
+    {
+      networking.networkmanager.enable = true;
+      thoughtfull.binaryCache.awsCredentialsFile = pkgs.writeText "fake-creds" "AWS_ACCESS_KEY_ID=x\nAWS_SECRET_ACCESS_KEY=y\n";
+    }
+  );
 
   headlessUnit = headless.config.systemd.services.system-pull;
   headlessTimer = headless.config.systemd.timers.system-pull.timerConfig;
   graphicalTimer = graphical.config.systemd.timers.system-pull.timerConfig;
+  networkManagerUnit = networkManager.config.systemd.services.system-pull;
 
   systemPullPkg = lib.head (
     builtins.filter (p: (p.name or "") == "system-pull") headless.config.environment.systemPackages
@@ -91,9 +105,16 @@ let
       # no-op after boot: if the daily timer's Persistent= catch-up fires
       # right after wake (Wi-Fi not yet reassociated), nothing blocks it. A
       # live nm-online check (no -s, which only checks the boot-time startup
-      # milestone) re-verifies connectivity on every start instead.
-      name = "waits for a live NetworkManager connectivity check before pulling, not just the stale network-online.target";
-      ok = headlessUnit.serviceConfig.ExecStartPre == "/run/current-system/sw/bin/nm-online -q -t 60";
+      # milestone) re-verifies connectivity on every start instead -- but only
+      # where NetworkManager is actually enabled, so nm-online is guaranteed
+      # to be installed.
+      name = "NetworkManager enabled: waits for a live connectivity check before pulling, not just the stale network-online.target";
+      ok =
+        networkManagerUnit.serviceConfig.ExecStartPre == "/run/current-system/sw/bin/nm-online -q -t 60";
+    }
+    {
+      name = "NetworkManager disabled (e.g. rpi4/networkd hosts): no ExecStartPre referencing nm-online, which wouldn't be installed";
+      ok = !(headlessUnit.serviceConfig ? ExecStartPre);
     }
     {
       name = "AWS credentials must not be loaded into system-pull.service's environment";

--- a/tests/system-pull.nix
+++ b/tests/system-pull.nix
@@ -84,6 +84,18 @@ let
       ok = headlessUnit.serviceConfig.ExecStart == "/run/current-system/sw/bin/system-pull";
     }
     {
+      # network-online.target is satisfied once at boot by
+      # NetworkManager-wait-online.service (Type=oneshot, RemainAfterExit=yes)
+      # and never re-checked. On a laptop that suspends, the target stays
+      # "active" straight through sleep/resume, so After=/Wants= on it is a
+      # no-op after boot: if the daily timer's Persistent= catch-up fires
+      # right after wake (Wi-Fi not yet reassociated), nothing blocks it. A
+      # live nm-online check (no -s, which only checks the boot-time startup
+      # milestone) re-verifies connectivity on every start instead.
+      name = "waits for a live NetworkManager connectivity check before pulling, not just the stale network-online.target";
+      ok = headlessUnit.serviceConfig.ExecStartPre == "/run/current-system/sw/bin/nm-online -q -t 60";
+    }
+    {
       name = "AWS credentials must not be loaded into system-pull.service's environment";
       ok = !(headlessUnit.serviceConfig ? EnvironmentFile);
     }

--- a/tests/system-pull.nix
+++ b/tests/system-pull.nix
@@ -109,8 +109,7 @@ let
       # where NetworkManager is actually enabled, so nm-online is guaranteed
       # to be installed.
       name = "NetworkManager enabled: waits for a live connectivity check before pulling, not just the stale network-online.target";
-      ok =
-        networkManagerUnit.serviceConfig.ExecStartPre == "/run/current-system/sw/bin/nm-online -q -t 60";
+      ok = networkManagerUnit.serviceConfig.ExecStartPre == "/run/current-system/sw/bin/nm-online -t 300";
     }
     {
       name = "NetworkManager disabled (e.g. rpi4/networkd hosts): no ExecStartPre referencing nm-online, which wouldn't be installed";


### PR DESCRIPTION
## Problem

`system-pull.service` on hydor (a laptop) sometimes fails right after waking from sleep:

```
Aug 08 14:17:30 hydor system-pull[1276418]: system-pull: fetching s3://thoughtfull-nix-cache/hosts/hydor/latest.json
Aug 08 14:17:35 hydor system-pull[1276426]: download failed: ... Could not connect to the endpoint URL ...
```

The unit has `After=`/`Wants=network-online.target`, so the working theory was that the target fired before Wi-Fi actually reassociated.

## Root cause

`network-online.target` is satisfied once at boot by `NetworkManager-wait-online.service` (`Type=oneshot`, `RemainAfterExit=yes`) and is never re-checked afterwards. On a laptop that suspends, the target stays "active" straight through sleep/resume -- so `After=`/`Wants=` on it is a no-op after boot.

`system-pull`'s daily timer (`OnCalendar=noon`, `Persistent=true`) fires its missed run immediately on wake if the laptop was asleep through the scheduled time. Since the stale target doesn't block anything, the pull runs before Wi-Fi has actually reassociated and fails trying to reach the S3 endpoint.

## Fix

Add an `ExecStartPre` running `nm-online -t 300` to `system-pull.service`. Unlike `nm-online -s` (which only checks the one-time boot startup milestone -- the same thing that's stale), plain `nm-online` does a live, fresh check for an actual active connection each time it runs, polling internally for up to 5 minutes to give Wi-Fi time to reassociate before the pull proceeds. No `-q`, so a timeout leaves `nm-online`'s own diagnostic (which connectivity state it was stuck in) in `journalctl -u system-pull` instead of a bare exit code.

Kept the existing `After=`/`Wants=network-online.target` since it's still correct at boot; comments explain why it isn't sufficient on its own. Referenced `nm-online` via `/run/current-system/sw/bin` (not a store path) to keep the unit byte-identical across generations, matching the existing convention for `ExecStart`.

The check is gated on `config.networking.networkmanager.enable`: `nm-online` is only installed when NixOS's NetworkManager module is enabled, and hosts like the rpi4-based ones (e.g. tislit) force `networking.networkmanager.enable = false` / `useNetworkd = true`, so referencing it unconditionally would have broken every `system-pull` run on those hosts.

A longer timeout (vs. a `Restart=on-failure` retry loop) was chosen deliberately: `nm-online` already polls internally until online-or-timeout, so extending the timeout doubles as the retry, confined to the connectivity precheck. `Restart=on-failure` would instead restart the *whole* oneshot -- including a real `switch-to-configuration` attempt -- on any failure, not just a slow network wait. Nothing else waits on this unit (it's timer-triggered, not in the boot path), and `Type=oneshot` disables `TimeoutStartSec` by default, so there's no competing systemd start-timeout to race against a long `nm-online` wait.

## Testing

- Extended the nix-eval test in `tests/system-pull.nix` to assert the `ExecStartPre` value when NetworkManager is enabled, and that no `ExecStartPre` is added when it's disabled (covering the rpi4/tislit case).
- Confirmed each test change fails against the prior module code and passes after the fix.
- `devenv tasks run devenv:git-hooks:run` passes.
